### PR TITLE
feat: Add security scanning to CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,21 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,72 @@
+name: Security
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  schedule:
+    # Run weekly on Monday at midnight
+    - cron: '0 0 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  vulnerability-scan:
+    name: Vulnerability Scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.24'
+
+      - name: Run govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+
+  gosec:
+    name: Security Analysis (gosec)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          args: '-no-fail -fmt sarif -out results.sarif ./...'
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+
+  trivy:
+    name: Trivy Vulnerability Scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test lint fmt clean tools check
+.PHONY: all build test lint fmt clean tools check security tools-security
 
 # Binary name
 BINARY_NAME=my-own-vpn
@@ -33,3 +33,12 @@ tools:
 
 # Run all checks (useful before committing)
 check: fmt lint test
+
+# Security scanning
+security:
+	govulncheck ./...
+
+# Install security tools
+tools-security:
+	go install golang.org/x/vuln/cmd/govulncheck@latest
+	go install github.com/securego/gosec/v2/cmd/gosec@latest

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x.x   | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+We take security seriously. If you discover a security vulnerability, please follow these steps:
+
+1. **Do NOT** create a public GitHub issue
+2. Use GitHub's private vulnerability reporting feature (Security tab > Report a vulnerability)
+3. Provide detailed information about the vulnerability
+4. Allow reasonable time for us to address the issue before public disclosure
+
+## Security Measures
+
+This project implements the following security measures:
+
+- **Dependency Scanning**: Automated scanning for known vulnerabilities in dependencies using govulncheck
+- **Static Analysis**: Code is scanned for security issues using gosec
+- **Filesystem Scanning**: Trivy scans for additional vulnerabilities and misconfigurations
+- **Credential Storage**: Sensitive data is stored in OS keychain or encrypted files
+- **No Hardcoded Secrets**: All credentials are provided by users at runtime
+- **Minimal Permissions**: Cloud resources use least-privilege security groups
+
+## Credential Security
+
+- Cloud provider credentials are stored in OS keychain where available
+- Fallback storage uses encryption (NaCl secretbox)
+- Credentials are never logged
+- WireGuard keys are generated fresh for each session
+
+## Security Scanning
+
+This project runs automated security scans:
+
+- **govulncheck**: Official Go vulnerability checker for dependencies
+- **gosec**: Comprehensive Go security analyzer
+- **trivy**: Filesystem and configuration scanner
+
+Scans run on every push, pull request, and weekly on a schedule.


### PR DESCRIPTION
## Summary

- Add `.github/workflows/security.yml` with three security scanning jobs:
  - **govulncheck**: Official Go vulnerability checker for dependency vulnerabilities
  - **gosec**: Static analysis security scanner with SARIF upload to GitHub Code Scanning
  - **trivy**: Filesystem vulnerability scanner with SARIF upload
- Create `SECURITY.md` with vulnerability reporting instructions
- Add `security` and `tools-security` targets to Makefile for local security scanning
- Update `dependabot.yml` with grouping for cleaner dependency update PRs

Security scans run on push, pull request, and weekly schedule (Monday midnight).

Closes #6

## Test plan

- [ ] Verify security workflow runs on this PR
- [ ] Check that govulncheck job completes successfully
- [ ] Verify gosec uploads SARIF to GitHub Code Scanning
- [ ] Verify trivy uploads SARIF to GitHub Code Scanning
- [ ] Check GitHub Security tab shows scan results after merge
- [ ] Run `make security` locally (after `make tools-security`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)