### PR TITLE
feat: Implement core application state machine (#10)

### DIFF
--- a/cmd/my-own-vpn/main.go
+++ b/cmd/my-own-vpn/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/gonfva/my-own-vpn/internal/app"
 	"github.com/gonfva/my-own-vpn/internal/ui"
 )
 
@@ -12,10 +14,16 @@ var Version = "dev"
 var (
 	tray           *ui.TrayApp
 	settingsWindow *ui.SettingsWindow
+	controller     *app.Controller
 )
 
 func main() {
 	fmt.Printf("My Own VPN v%s\n", Version)
+
+	// Create the controller
+	controller = app.NewController()
+	controller.SetOnStateChange(onControllerStateChange)
+	controller.SetOnError(onControllerError)
 
 	// Create the settings window
 	settingsWindow = ui.NewSettingsWindow()
@@ -40,11 +48,21 @@ func main() {
 }
 
 func onConnect() {
-	fmt.Println("Connect clicked - not yet implemented")
+	go func() {
+		ctx := context.Background()
+		if err := controller.Connect(ctx); err != nil {
+			tray.SetError(err.Error())
+		}
+	}()
 }
 
 func onDisconnect() {
-	fmt.Println("Disconnect clicked - not yet implemented")
+	go func() {
+		ctx := context.Background()
+		if err := controller.Disconnect(ctx); err != nil {
+			tray.SetError(err.Error())
+		}
+	}()
 }
 
 func onSettings() {
@@ -60,4 +78,29 @@ func onSettingsSaved(config ui.SettingsConfig) {
 func onQuit() {
 	fmt.Println("Quit clicked - shutting down")
 	settingsWindow.StopFyneLoop()
+}
+
+func onControllerStateChange(state app.State, message string) {
+	fmt.Printf("State changed: %s - %s\n", state, message)
+
+	switch state {
+	case app.StateDisconnected:
+		tray.UpdateStatus("Disconnected", false)
+
+	case app.StateProvisioning, app.StateConnecting:
+		tray.SetConnecting()
+
+	case app.StateConnected:
+		tray.UpdateStatus("Connected", true)
+
+	case app.StateDisconnecting, app.StateDeprovisioning:
+		tray.SetDisconnecting()
+
+	case app.StateError:
+		tray.SetError(message)
+	}
+}
+
+func onControllerError(err error) {
+	fmt.Printf("Controller error: %v\n", err)
 }

--- a/internal/app/controller.go
+++ b/internal/app/controller.go
@@ -1,0 +1,307 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Controller manages the VPN lifecycle state machine
+type Controller struct {
+	mu    sync.RWMutex // Thread-safe access to all fields
+	state State        // Current state of the state machine
+
+	// Callbacks for UI notifications
+	onStateChange func(state State, message string)
+	onError       func(err error)
+
+	// Session tracking
+	sessionStart time.Time // When connection was established
+	errorMsg     string    // Last error message (for Error state)
+
+	// Cancellation support
+	cancelFunc context.CancelFunc // For aborting current operation
+}
+
+// validTransitions defines allowed state transitions
+// Key is current state, value is set of allowed next states
+var validTransitions = map[State]map[State]bool{
+	StateDisconnected: {
+		StateProvisioning: true, // Connect initiated
+	},
+	StateProvisioning: {
+		StateConnecting: true, // Provision successful
+		StateError:      true, // Provision failed
+	},
+	StateConnecting: {
+		StateConnected: true, // Connection established
+		StateError:     true, // Connection failed
+	},
+	StateConnected: {
+		StateDisconnecting: true, // Disconnect initiated
+	},
+	StateDisconnecting: {
+		StateDeprovisioning: true, // Disconnection completed
+	},
+	StateDeprovisioning: {
+		StateDisconnected: true, // Cleanup completed
+	},
+	StateError: {
+		StateDisconnected: true, // Cleanup after error
+	},
+}
+
+// NewController creates a new Controller instance
+func NewController() *Controller {
+	return &Controller{
+		state: StateDisconnected,
+	}
+}
+
+// State returns the current state (thread-safe)
+func (c *Controller) State() State {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.state
+}
+
+// SetOnStateChange sets the callback function called when state changes
+func (c *Controller) SetOnStateChange(callback func(state State, message string)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onStateChange = callback
+}
+
+// SetOnError sets the callback function called when an error occurs
+func (c *Controller) SetOnError(callback func(err error)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onError = callback
+}
+
+// Connect initiates the connection flow
+// This is a stub implementation that simulates the provisioning and connection process
+func (c *Controller) Connect(ctx context.Context) error {
+	c.mu.Lock()
+
+	// Check if we're already connected or connecting
+	if c.state != StateDisconnected {
+		c.mu.Unlock()
+		return fmt.Errorf("cannot connect: current state is %s", c.state)
+	}
+
+	// Create cancellable context
+	ctx, cancel := context.WithCancel(ctx)
+	c.cancelFunc = cancel
+
+	// Transition to Provisioning
+	if err := c.setState(StateProvisioning, "Starting provisioning..."); err != nil {
+		c.mu.Unlock()
+		return err
+	}
+	c.mu.Unlock()
+
+	// Launch async operation
+	go c.doConnect(ctx)
+
+	return nil
+}
+
+// Disconnect initiates the disconnection flow
+// This is a stub implementation that simulates the disconnection and deprovisioning process
+func (c *Controller) Disconnect(ctx context.Context) error {
+	c.mu.Lock()
+
+	// Check if we're connected
+	if c.state != StateConnected {
+		c.mu.Unlock()
+		return fmt.Errorf("cannot disconnect: not connected (state: %s)", c.state)
+	}
+
+	// Transition to Disconnecting
+	if err := c.setState(StateDisconnecting, "Disconnecting..."); err != nil {
+		c.mu.Unlock()
+		return err
+	}
+	c.mu.Unlock()
+
+	// Launch async operation
+	go c.doDisconnect(ctx)
+
+	return nil
+}
+
+// Cancel aborts the current operation
+func (c *Controller) Cancel() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Call cancel function if operation in progress
+	if c.cancelFunc != nil {
+		c.cancelFunc()
+		c.cancelFunc = nil
+	}
+}
+
+// SessionDuration returns the time since connection was established
+// Returns 0 if not connected
+func (c *Controller) SessionDuration() time.Duration {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	// If not connected, return 0
+	if c.state != StateConnected || c.sessionStart.IsZero() {
+		return 0
+	}
+
+	// Return time elapsed since connection
+	return time.Since(c.sessionStart)
+}
+
+// canTransition checks if transition from -> to is valid
+func (c *Controller) canTransition(from, to State) bool {
+	if allowed, ok := validTransitions[from]; ok {
+		return allowed[to]
+	}
+	return false
+}
+
+// setState transitions to new state with validation
+// Must be called with lock held
+func (c *Controller) setState(newState State, message string) error {
+	if !c.canTransition(c.state, newState) {
+		return fmt.Errorf("invalid state transition: %s -> %s", c.state, newState)
+	}
+
+	c.state = newState
+
+	// Special handling for Connected state
+	if newState == StateConnected {
+		c.sessionStart = time.Now()
+	}
+
+	// Special handling for Disconnected state
+	if newState == StateDisconnected {
+		c.sessionStart = time.Time{} // Zero value
+		c.errorMsg = ""
+		c.cancelFunc = nil
+	}
+
+	// Special handling for Error state
+	if newState == StateError && message != "" {
+		c.errorMsg = message
+	}
+
+	// Notify callback (non-blocking)
+	if c.onStateChange != nil {
+		go c.onStateChange(newState, message)
+	}
+
+	return nil
+}
+
+// doConnect performs the connection process (stub implementation)
+func (c *Controller) doConnect(ctx context.Context) {
+	// STUB: Simulate provisioning
+	select {
+	case <-ctx.Done():
+		c.handleError(ctx.Err(), "Operation cancelled during provisioning")
+		return
+	case <-time.After(2 * time.Second):
+		// Continue
+	}
+
+	c.mu.Lock()
+	if err := c.setState(StateConnecting, "Establishing connection..."); err != nil {
+		c.mu.Unlock()
+		return
+	}
+	c.mu.Unlock()
+
+	// STUB: Simulate connecting
+	select {
+	case <-ctx.Done():
+		c.handleError(ctx.Err(), "Operation cancelled during connection")
+		return
+	case <-time.After(2 * time.Second):
+		// Continue
+	}
+
+	c.mu.Lock()
+	if err := c.setState(StateConnected, "Connected successfully"); err != nil {
+		c.mu.Unlock()
+		return
+	}
+	c.mu.Unlock()
+}
+
+// doDisconnect performs the disconnection process (stub implementation)
+func (c *Controller) doDisconnect(ctx context.Context) {
+	// STUB: Simulate disconnecting
+	select {
+	case <-ctx.Done():
+		// For disconnect, we continue even if cancelled to ensure cleanup
+	case <-time.After(1 * time.Second):
+		// Continue
+	}
+
+	c.mu.Lock()
+	if err := c.setState(StateDeprovisioning, "Cleaning up resources..."); err != nil {
+		c.mu.Unlock()
+		return
+	}
+	c.mu.Unlock()
+
+	// STUB: Simulate deprovisioning
+	select {
+	case <-ctx.Done():
+		// Continue cleanup regardless
+	case <-time.After(1 * time.Second):
+		// Continue
+	}
+
+	c.mu.Lock()
+	if err := c.setState(StateDisconnected, "Disconnected"); err != nil {
+		c.mu.Unlock()
+		return
+	}
+	c.mu.Unlock()
+}
+
+// handleError is called when an error occurs during operations
+func (c *Controller) handleError(err error, message string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Transition to Error state
+	if setErr := c.setState(StateError, message); setErr != nil {
+		// If we can't transition, we have a serious problem
+		// In production, use proper logger
+		return
+	}
+
+	// Notify error callback
+	if c.onError != nil {
+		go c.onError(err)
+	}
+
+	// Attempt cleanup in background
+	go c.cleanup()
+}
+
+// cleanup performs cleanup after error
+func (c *Controller) cleanup() {
+	// STUB: In future, this will:
+	// 1. Call provider.Deprovision()
+	// 2. Tear down WireGuard tunnel
+	// 3. Release resources
+
+	time.Sleep(500 * time.Millisecond) // Simulate cleanup
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Transition back to Disconnected after cleanup
+	_ = c.setState(StateDisconnected, "Cleanup completed")
+}

--- a/internal/app/controller_test.go
+++ b/internal/app/controller_test.go
@@ -1,0 +1,415 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNewController(t *testing.T) {
+	c := NewController()
+
+	if c == nil {
+		t.Fatal("NewController returned nil")
+	}
+
+	if c.State() != StateDisconnected {
+		t.Errorf("expected initial state StateDisconnected, got %v", c.State())
+	}
+
+	if c.SessionDuration() != 0 {
+		t.Errorf("expected session duration 0, got %v", c.SessionDuration())
+	}
+}
+
+func TestStateString(t *testing.T) {
+	tests := []struct {
+		state    State
+		expected string
+	}{
+		{StateDisconnected, "Disconnected"},
+		{StateProvisioning, "Provisioning"},
+		{StateConnecting, "Connecting"},
+		{StateConnected, "Connected"},
+		{StateDisconnecting, "Disconnecting"},
+		{StateDeprovisioning, "Deprovisioning"},
+		{StateError, "Error"},
+		{State(999), "Unknown"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.state.String(); got != tt.expected {
+			t.Errorf("State(%d).String() = %q, want %q", tt.state, got, tt.expected)
+		}
+	}
+}
+
+func TestValidTransitions(t *testing.T) {
+	c := NewController()
+
+	tests := []struct {
+		from  State
+		to    State
+		valid bool
+	}{
+		{StateDisconnected, StateProvisioning, true},
+		{StateDisconnected, StateConnected, false},
+		{StateDisconnected, StateConnecting, false},
+		{StateProvisioning, StateConnecting, true},
+		{StateProvisioning, StateError, true},
+		{StateProvisioning, StateDisconnected, false},
+		{StateConnecting, StateConnected, true},
+		{StateConnecting, StateError, true},
+		{StateConnecting, StateDisconnecting, false},
+		{StateConnected, StateDisconnecting, true},
+		{StateConnected, StateDisconnected, false},
+		{StateConnected, StateProvisioning, false},
+		{StateDisconnecting, StateDeprovisioning, true},
+		{StateDisconnecting, StateDisconnected, false},
+		{StateDeprovisioning, StateDisconnected, true},
+		{StateDeprovisioning, StateError, false},
+		{StateError, StateDisconnected, true},
+		{StateError, StateConnecting, false},
+	}
+
+	for _, tt := range tests {
+		got := c.canTransition(tt.from, tt.to)
+		if got != tt.valid {
+			t.Errorf("canTransition(%v, %v) = %v, want %v", tt.from, tt.to, got, tt.valid)
+		}
+	}
+}
+
+func TestSetStateCallbacks(t *testing.T) {
+	c := NewController()
+
+	done := make(chan bool)
+	var receivedState State
+	var receivedMsg string
+
+	c.SetOnStateChange(func(state State, msg string) {
+		receivedState = state
+		receivedMsg = msg
+		done <- true
+	})
+
+	// Manually set state to test callback
+	c.mu.Lock()
+	err := c.setState(StateProvisioning, "test message")
+	c.mu.Unlock()
+
+	if err != nil {
+		t.Fatalf("setState returned error: %v", err)
+	}
+
+	// Wait for callback
+	select {
+	case <-done:
+		// Callback was called
+	case <-time.After(1 * time.Second):
+		t.Fatal("state change callback not called within timeout")
+	}
+
+	if receivedState != StateProvisioning {
+		t.Errorf("expected StateProvisioning, got %v", receivedState)
+	}
+
+	if receivedMsg != "test message" {
+		t.Errorf("expected 'test message', got %q", receivedMsg)
+	}
+}
+
+func TestConnectStub(t *testing.T) {
+	c := NewController()
+
+	done := make(chan bool, 10)
+	var stateChanges []State
+	var mu sync.Mutex
+
+	c.SetOnStateChange(func(state State, msg string) {
+		mu.Lock()
+		stateChanges = append(stateChanges, state)
+		mu.Unlock()
+		done <- true
+	})
+
+	ctx := context.Background()
+	err := c.Connect(ctx)
+
+	if err != nil {
+		t.Fatalf("Connect returned error: %v", err)
+	}
+
+	// Wait for 3 state changes: Provisioning -> Connecting -> Connected
+	for i := 0; i < 3; i++ {
+		select {
+		case <-done:
+			// Got state change
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timeout waiting for state change %d", i+1)
+		}
+	}
+
+	// Should have transitioned: Provisioning -> Connecting -> Connected
+	expectedStates := []State{StateProvisioning, StateConnecting, StateConnected}
+
+	mu.Lock()
+	if len(stateChanges) != len(expectedStates) {
+		t.Errorf("expected %d state changes, got %d: %v", len(expectedStates), len(stateChanges), stateChanges)
+	}
+
+	for i, expected := range expectedStates {
+		if i >= len(stateChanges) {
+			break
+		}
+		if stateChanges[i] != expected {
+			t.Errorf("state change %d: expected %v, got %v", i, expected, stateChanges[i])
+		}
+	}
+	mu.Unlock()
+
+	if c.State() != StateConnected {
+		t.Errorf("expected final state Connected, got %v", c.State())
+	}
+}
+
+func TestDisconnectStub(t *testing.T) {
+	c := NewController()
+
+	// First manually set to Connected state
+	c.mu.Lock()
+	c.state = StateConnected
+	c.sessionStart = time.Now()
+	c.mu.Unlock()
+
+	done := make(chan bool, 10)
+	var stateChanges []State
+	var mu sync.Mutex
+
+	c.SetOnStateChange(func(state State, msg string) {
+		mu.Lock()
+		stateChanges = append(stateChanges, state)
+		mu.Unlock()
+		done <- true
+	})
+
+	ctx := context.Background()
+	err := c.Disconnect(ctx)
+
+	if err != nil {
+		t.Fatalf("Disconnect returned error: %v", err)
+	}
+
+	// Wait for 3 state changes: Disconnecting -> Deprovisioning -> Disconnected
+	for i := 0; i < 3; i++ {
+		select {
+		case <-done:
+			// Got state change
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timeout waiting for state change %d", i+1)
+		}
+	}
+
+	// Should have transitioned: Disconnecting -> Deprovisioning -> Disconnected
+	expectedStates := []State{StateDisconnecting, StateDeprovisioning, StateDisconnected}
+
+	mu.Lock()
+	if len(stateChanges) != len(expectedStates) {
+		t.Errorf("expected %d state changes, got %d: %v", len(expectedStates), len(stateChanges), stateChanges)
+	}
+	mu.Unlock()
+
+	if c.State() != StateDisconnected {
+		t.Errorf("expected final state Disconnected, got %v", c.State())
+	}
+}
+
+func TestSessionDuration(t *testing.T) {
+	c := NewController()
+
+	// When disconnected, duration should be 0
+	if d := c.SessionDuration(); d != 0 {
+		t.Errorf("expected 0 duration when disconnected, got %v", d)
+	}
+
+	// Simulate connection
+	c.mu.Lock()
+	c.sessionStart = time.Now().Add(-5 * time.Minute)
+	c.state = StateConnected
+	c.mu.Unlock()
+
+	// Duration should be approximately 5 minutes
+	d := c.SessionDuration()
+	if d < 4*time.Minute || d > 6*time.Minute {
+		t.Errorf("expected ~5 minutes, got %v", d)
+	}
+
+	// Manually reset to disconnected state (bypass validation for testing)
+	c.mu.Lock()
+	c.state = StateDisconnected
+	c.sessionStart = time.Time{}
+	c.mu.Unlock()
+
+	if d := c.SessionDuration(); d != 0 {
+		t.Errorf("expected 0 duration after disconnect, got %v", d)
+	}
+}
+
+func TestCancel(t *testing.T) {
+	c := NewController()
+
+	ctx := context.Background()
+
+	// Start connection
+	err := c.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect returned error: %v", err)
+	}
+
+	// Wait a bit
+	time.Sleep(500 * time.Millisecond)
+
+	// Cancel should work
+	c.Cancel()
+
+	// Check that cancelFunc was called
+	c.mu.RLock()
+	if c.cancelFunc != nil {
+		t.Error("cancelFunc should be nil after Cancel()")
+	}
+	c.mu.RUnlock()
+
+	// Wait for error handling to complete
+	time.Sleep(1 * time.Second)
+
+	// Should end up in Error or Disconnected state after cleanup
+	finalState := c.State()
+	if finalState != StateError && finalState != StateDisconnected {
+		t.Errorf("expected Error or Disconnected state after cancel, got %v", finalState)
+	}
+}
+
+func TestInvalidStateOperations(t *testing.T) {
+	c := NewController()
+	ctx := context.Background()
+
+	// Try to disconnect when not connected
+	err := c.Disconnect(ctx)
+	if err == nil {
+		t.Error("expected error when disconnecting from Disconnected state")
+	}
+
+	// Manually set to Connected
+	c.mu.Lock()
+	c.state = StateConnected
+	c.mu.Unlock()
+
+	// Try to connect when already connected
+	err = c.Connect(ctx)
+	if err == nil {
+		t.Error("expected error when connecting from Connected state")
+	}
+
+	// Manually set to Connecting
+	c.mu.Lock()
+	c.state = StateConnecting
+	c.mu.Unlock()
+
+	// Try to connect when in intermediate state
+	err = c.Connect(ctx)
+	if err == nil {
+		t.Error("expected error when connecting from Connecting state")
+	}
+}
+
+func TestThreadSafety(t *testing.T) {
+	c := NewController()
+
+	// Run with -race flag to detect races
+	done := make(chan bool)
+
+	// Multiple goroutines reading state
+	for i := 0; i < 10; i++ {
+		go func() {
+			for j := 0; j < 100; j++ {
+				_ = c.State()
+				_ = c.SessionDuration()
+			}
+			done <- true
+		}()
+	}
+
+	// One goroutine writing state
+	go func() {
+		ctx := context.Background()
+		_ = c.Connect(ctx)
+		time.Sleep(100 * time.Millisecond)
+		done <- true
+	}()
+
+	// Wait for all goroutines
+	for i := 0; i < 11; i++ {
+		<-done
+	}
+}
+
+func TestErrorCallback(t *testing.T) {
+	c := NewController()
+
+	// Set controller to a state that can transition to Error (Provisioning)
+	c.mu.Lock()
+	c.state = StateProvisioning
+	c.mu.Unlock()
+
+	errorDone := make(chan bool)
+	var receivedError error
+
+	c.SetOnError(func(err error) {
+		receivedError = err
+		errorDone <- true
+	})
+
+	// Manually trigger an error
+	testErr := context.Canceled
+	c.handleError(testErr, "test error")
+
+	// Wait for error callback
+	select {
+	case <-errorDone:
+		// Error callback was called
+	case <-time.After(1 * time.Second):
+		t.Fatal("error callback was not called within timeout")
+	}
+
+	if !errors.Is(receivedError, testErr) {
+		t.Errorf("expected error %v, got %v", testErr, receivedError)
+	}
+
+	// Wait for cleanup to complete
+	time.Sleep(1 * time.Second)
+
+	// Should be back to Disconnected after cleanup
+	if c.State() != StateDisconnected {
+		t.Errorf("expected Disconnected state after error cleanup, got %v", c.State())
+	}
+}
+
+func TestInvalidTransitionRejected(t *testing.T) {
+	c := NewController()
+
+	// Try an invalid transition
+	c.mu.Lock()
+	err := c.setState(StateConnected, "invalid")
+	c.mu.Unlock()
+
+	if err == nil {
+		t.Error("expected error for invalid state transition Disconnected -> Connected")
+	}
+
+	// State should remain unchanged
+	if c.State() != StateDisconnected {
+		t.Errorf("expected state to remain Disconnected, got %v", c.State())
+	}
+}

--- a/internal/app/state.go
+++ b/internal/app/state.go
@@ -1,0 +1,43 @@
+package app
+
+// State represents the current state of the VPN connection lifecycle
+type State int
+
+const (
+	// StateDisconnected indicates no active connection or provisioning
+	StateDisconnected State = iota
+	// StateProvisioning indicates cloud infrastructure is being created
+	StateProvisioning
+	// StateConnecting indicates WireGuard connection is being established
+	StateConnecting
+	// StateConnected indicates VPN connection is active
+	StateConnected
+	// StateDisconnecting indicates VPN connection is being torn down
+	StateDisconnecting
+	// StateDeprovisioning indicates cloud infrastructure is being destroyed
+	StateDeprovisioning
+	// StateError indicates an error occurred during operation
+	StateError
+)
+
+// String returns a human-readable string representation of the State
+func (s State) String() string {
+	switch s {
+	case StateDisconnected:
+		return "Disconnected"
+	case StateProvisioning:
+		return "Provisioning"
+	case StateConnecting:
+		return "Connecting"
+	case StateConnected:
+		return "Connected"
+	case StateDisconnecting:
+		return "Disconnecting"
+	case StateDeprovisioning:
+		return "Deprovisioning"
+	case StateError:
+		return "Error"
+	default:
+		return "Unknown"
+	}
+}


### PR DESCRIPTION
## Summary

Implements issue #10 - Core application state machine that manages the VPN lifecycle.

This PR creates the central controller that coordinates between the UI, cloud providers (future), and WireGuard client (future).

## Changes

### New Files
- `internal/app/state.go` - State enum with 7 states and String() method
- `internal/app/controller.go` - Core Controller implementation with state machine logic
- `internal/app/controller_test.go` - Comprehensive test suite (12 tests)

### Modified Files
- `cmd/my-own-vpn/main.go` - Wired controller to UI callbacks

## Key Features

1. **State Machine**: 7 states with validated transitions
   - StateDisconnected
   - StateProvisioning
   - StateConnecting  
   - StateConnected
   - StateDisconnecting
   - StateDeprovisioning
   - StateError

2. **Thread Safety**: All state access protected by RWMutex

3. **Callback-based UI Notifications**: Controller notifies UI of state changes and errors

4. **Context Cancellation**: Support for aborting ongoing operations

5. **Session Duration Tracking**: Tracks time since connection established

6. **Error Handling**: Automatic cleanup on errors, always transitions through Error state

7. **Stub Implementation**: Connect/Disconnect simulate the full flow with time delays

## Architecture

Controller states are **separate** from TrayApp UI states:
- Controller manages detailed internal states (Provisioning, Deprovisioning)
- TrayApp shows simplified user-facing states
- State mapping happens in `main.go` via `onControllerStateChange()` callback

Example: Both StateProvisioning and StateConnecting map to TrayApp's "Connecting" state.

## Testing

- ✅ All 12 tests pass
- ✅ Race detector enabled (no race conditions)
- ✅ Linter passes (golangci-lint)
- ✅ Thread safety test with 10 concurrent readers + 1 writer
- ✅ State transition validation tests
- ✅ Callback notification tests
- ✅ Session duration tracking tests

## Future Integration

When implementing providers and WireGuard:
- Replace `time.Sleep` in `doConnect()` with actual `provider.Provision()` and `wireguard.Connect()` calls
- Replace `time.Sleep` in `doDisconnect()` with actual teardown calls
- Enhance `cleanup()` to actually release cloud resources
- Add proper error handling for provider/wireguard errors

## Acceptance Criteria Met

- [x] State enum defined with all 7 states
- [x] Controller manages state transitions
- [x] Invalid transitions are rejected via `canTransition()`
- [x] Callbacks notify UI of state changes
- [x] `Connect()` initiates connection flow (stub with state transitions)
- [x] `Disconnect()` initiates disconnection flow (stub with state transitions)
- [x] `Cancel()` can abort ongoing operations
- [x] `SessionDuration()` returns time since connection
- [x] Errors trigger cleanup and Error state
- [x] Tests created with race detector enabled
- [x] Wired to UI in main.go

## Manual Testing

To manually test:
```bash
go build -o my-own-vpn ./cmd/my-own-vpn
./my-own-vpn
# Click Connect in tray - should see "Connecting..." then "Connected"
# Click Disconnect - should see "Disconnecting..." then "Disconnected"
```

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)