### PR TITLE
fix: Fix double 'v' in version and systray init error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,10 @@ jobs:
       - name: Get version from tag
         id: version
         shell: bash
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        run: |
+          # Strip 'v' prefix from tag (v0.0.5 -> 0.0.5)
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Run tests
         run: go test -v ./internal/config/... ./internal/app/...

--- a/cmd/my-own-vpn/main.go
+++ b/cmd/my-own-vpn/main.go
@@ -55,8 +55,11 @@ func main() {
 		onQuit,
 	)
 
-	// Initialize the system tray menu
-	tray.Setup()
+	// Initialize the system tray menu after Fyne app has started
+	// (systray requires the event loop to be running)
+	settingsWindow.SetOnStarted(func() {
+		tray.Setup()
+	})
 
 	// Run Fyne event loop on main goroutine (required by GLFW on Windows/macOS)
 	// This blocks until Quit is called

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -78,6 +78,16 @@ func (s *SettingsWindow) GetFyneApp() fyne.App {
 	return s.fyneApp
 }
 
+// SetOnStarted registers a callback to be called when the Fyne app has started
+func (s *SettingsWindow) SetOnStarted(callback func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.fyneApp == nil {
+		s.fyneApp = app.New()
+	}
+	s.fyneApp.Lifecycle().SetOnStarted(callback)
+}
+
 // Show displays the settings window
 func (s *SettingsWindow) Show() {
 	s.mu.Lock()

--- a/internal/ui/settings_stub.go
+++ b/internal/ui/settings_stub.go
@@ -29,6 +29,14 @@ func (s *SettingsWindow) GetFyneApp() interface{} {
 	return nil
 }
 
+// SetOnStarted registers a callback (stub - calls immediately without CGO)
+func (s *SettingsWindow) SetOnStarted(callback func()) {
+	// In stub implementation, just call immediately since there's no event loop
+	if callback != nil {
+		callback()
+	}
+}
+
 // Show displays the settings window (stub - no-op without CGO)
 func (s *SettingsWindow) Show() {
 	s.mu.Lock()


### PR DESCRIPTION
## Summary
- Strip 'v' prefix from git tag in release workflow so version displays as "My Own VPN v0.0.5" instead of "My Own VPN vv0.0.5"
- Use Fyne lifecycle hook (`SetOnStarted`) to initialize systray after event loop starts, fixing "tray not ready yet" error

## Test plan
- [x] Build passes without CGO
- [x] Tests pass without CGO
- [x] Lint passes
- [ ] Manual testing to verify version displays correctly
- [ ] Manual testing to verify no systray error on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)