### PR TITLE
feat: Implement EC2 instance provisioning with WireGuard (#21)

### DIFF
--- a/internal/provider/aws/aws.go
+++ b/internal/provider/aws/aws.go
@@ -35,6 +35,11 @@ type Provider struct {
 	routeTableID      string
 	securityGroupID   string
 	instanceID        string
+	keyPairName       string
+
+	// Cached server info for GetStatus
+	serverPublicKey string
+	serverPublicIP  string
 }
 
 // New creates a new AWS provider with the given credentials and region.
@@ -99,40 +104,98 @@ func (p *Provider) ListRegions(ctx context.Context) ([]provider.Region, error) {
 }
 
 // Provision creates all necessary AWS infrastructure for a VPN server.
-// This is a stub implementation that will be completed in subsequent issues.
+// It creates networking resources, launches an EC2 instance with WireGuard,
+// and waits for the server to be ready.
 func (p *Provider) Provision(ctx context.Context, cfg provider.ProvisionConfig) (*provider.ServerInfo, error) {
-	// TODO: Implement in subsequent issues:
-	// 1. Create VPC
-	// 2. Create subnet
-	// 3. Create Internet Gateway
-	// 4. Create route table
-	// 5. Create security group
-	// 6. Create key pair
-	// 7. Launch EC2 instance
-	// 8. Wait for instance to be running
-	// 9. Configure WireGuard on instance
-	return nil, ErrNotImplemented
+	// Step 1: Create networking infrastructure (VPC, IGW, Subnet, Route Table, Security Group)
+	if err := p.createNetworking(ctx); err != nil {
+		// Attempt to clean up any partially created resources
+		_ = p.deleteNetworking(ctx)
+		return nil, fmt.Errorf("failed to create networking: %w", err)
+	}
+
+	// Step 2: Launch EC2 instance with WireGuard user-data
+	if err := p.launchInstance(ctx, cfg.InstanceType); err != nil {
+		// Clean up on failure
+		_ = p.deleteKeyPair(ctx)
+		_ = p.deleteNetworking(ctx)
+		return nil, fmt.Errorf("failed to launch instance: %w", err)
+	}
+
+	// Step 3: Wait for instance to be running
+	if err := p.waitForInstanceRunning(ctx); err != nil {
+		// Clean up on failure
+		_ = p.terminateInstance(ctx)
+		_ = p.deleteKeyPair(ctx)
+		_ = p.deleteNetworking(ctx)
+		return nil, fmt.Errorf("failed waiting for instance: %w", err)
+	}
+
+	// Step 4: Get the public IP
+	publicIP, err := p.getInstancePublicIP(ctx)
+	if err != nil {
+		// Clean up on failure
+		_ = p.terminateInstance(ctx)
+		_ = p.deleteKeyPair(ctx)
+		_ = p.deleteNetworking(ctx)
+		return nil, fmt.Errorf("failed to get public IP: %w", err)
+	}
+	p.serverPublicIP = publicIP
+
+	// Step 5: Wait for WireGuard to be ready and get the public key
+	pubKey, err := p.waitForWireGuardReady(ctx)
+	if err != nil {
+		// Clean up on failure
+		_ = p.terminateInstance(ctx)
+		_ = p.deleteKeyPair(ctx)
+		_ = p.deleteNetworking(ctx)
+		return nil, fmt.Errorf("failed waiting for WireGuard: %w", err)
+	}
+	p.serverPublicKey = pubKey
+
+	return &provider.ServerInfo{
+		PublicIP:        publicIP,
+		WireGuardPort:   wireGuardPort,
+		ServerPublicKey: pubKey,
+	}, nil
 }
 
 // Deprovision tears down all AWS infrastructure created by Provision.
-// This is a stub implementation that will be completed in subsequent issues.
+// It terminates the EC2 instance, deletes the key pair, and cleans up all networking resources.
 func (p *Provider) Deprovision(ctx context.Context) error {
-	// TODO: Implement in subsequent issues:
-	// 1. Terminate EC2 instance
-	// 2. Delete key pair
-	// 3. Delete security group
-	// 4. Delete route table
-	// 5. Detach and delete Internet Gateway
-	// 6. Delete subnet
-	// 7. Delete VPC
-	if p.instanceID == "" {
+	if p.instanceID == "" && p.vpcID == "" {
 		return ErrNotProvisioned
 	}
-	return ErrNotImplemented
+
+	var errs []error
+
+	// Step 1: Terminate EC2 instance (must be done before networking cleanup)
+	if err := p.terminateInstance(ctx); err != nil {
+		errs = append(errs, fmt.Errorf("terminate instance: %w", err))
+	}
+
+	// Step 2: Delete key pair
+	if err := p.deleteKeyPair(ctx); err != nil {
+		errs = append(errs, fmt.Errorf("delete key pair: %w", err))
+	}
+
+	// Step 3: Delete networking resources
+	if err := p.deleteNetworking(ctx); err != nil {
+		errs = append(errs, fmt.Errorf("delete networking: %w", err))
+	}
+
+	// Clear cached server info
+	p.serverPublicKey = ""
+	p.serverPublicIP = ""
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to deprovision: %v", errs)
+	}
+
+	return nil
 }
 
 // GetStatus returns the current status of the provisioned infrastructure.
-// This is a stub implementation that will be completed in subsequent issues.
 func (p *Provider) GetStatus(ctx context.Context) (*provider.InfraStatus, error) {
 	if p.instanceID == "" {
 		return &provider.InfraStatus{
@@ -141,10 +204,43 @@ func (p *Provider) GetStatus(ctx context.Context) (*provider.InfraStatus, error)
 		}, nil
 	}
 
-	// TODO: Implement in subsequent issues:
-	// 1. Describe EC2 instance
-	// 2. Map instance state to InfraStatus
-	return nil, ErrNotImplemented
+	// Get the instance state
+	state, err := p.getInstanceState(ctx)
+	if err != nil {
+		return &provider.InfraStatus{
+			State:   provider.StateError,
+			Message: fmt.Sprintf("Failed to get instance state: %v", err),
+		}, nil
+	}
+
+	// Map EC2 instance state to InfraStatus
+	switch state {
+	case "pending":
+		return &provider.InfraStatus{
+			State:   provider.StateProvisioning,
+			Message: "Instance is starting",
+		}, nil
+	case "running":
+		return &provider.InfraStatus{
+			State:   provider.StateRunning,
+			Message: fmt.Sprintf("Instance running at %s", p.serverPublicIP),
+		}, nil
+	case "stopping", "stopped":
+		return &provider.InfraStatus{
+			State:   provider.StateStopped,
+			Message: "Instance is stopped",
+		}, nil
+	case "shutting-down", "terminated":
+		return &provider.InfraStatus{
+			State:   provider.StateNotFound,
+			Message: "Instance has been terminated",
+		}, nil
+	default:
+		return &provider.InfraStatus{
+			State:   provider.StateError,
+			Message: fmt.Sprintf("Unknown instance state: %s", state),
+		}, nil
+	}
 }
 
 // EstimateCost returns an estimate of the hourly cost for the given config.

--- a/internal/provider/aws/aws_test.go
+++ b/internal/provider/aws/aws_test.go
@@ -121,20 +121,25 @@ func TestListRegions(t *testing.T) {
 	}
 }
 
-func TestProvisionNotImplemented(t *testing.T) {
+func TestProvisionFailsWithInvalidCredentials(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
 	ctx := context.Background()
 
-	p, err := New(ctx, "test-access-key", "test-secret-key", "us-east-1")
+	p, err := New(ctx, "INVALID_ACCESS_KEY", "invalid_secret_key", "us-east-1")
 	if err != nil {
 		t.Fatalf("New() returned error: %v", err)
 	}
 
+	// Provision should fail due to invalid credentials when trying to create VPC
 	_, err = p.Provision(ctx, provider.ProvisionConfig{
 		Region:       "us-east-1",
 		InstanceType: "t3.micro",
 	})
-	if !errors.Is(err, ErrNotImplemented) {
-		t.Errorf("expected ErrNotImplemented, got: %v", err)
+	if err == nil {
+		t.Error("expected error for invalid credentials during provision")
 	}
 }
 

--- a/internal/provider/aws/instance.go
+++ b/internal/provider/aws/instance.go
@@ -1,0 +1,412 @@
+package aws
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// Instance constants
+const (
+	// defaultInstanceType is the default EC2 instance type
+	defaultInstanceType = "t3.micro"
+
+	// instanceWaitTimeout is the maximum time to wait for instance operations
+	instanceWaitTimeout = 10 * time.Minute
+
+	// wireGuardReadyTimeout is the maximum time to wait for WireGuard to be ready
+	wireGuardReadyTimeout = 5 * time.Minute
+
+	// wireGuardPollInterval is how often to check if WireGuard is ready
+	wireGuardPollInterval = 10 * time.Second
+)
+
+// generateUserData returns the cloud-init script to install and configure WireGuard.
+// The script generates keys on the instance and outputs the public key to a log file.
+func generateUserData() string {
+	script := `#!/bin/bash
+set -e
+
+# Log output for debugging
+exec > >(tee /var/log/wireguard-setup.log) 2>&1
+echo "Starting WireGuard setup..."
+
+# Install WireGuard
+apt-get update
+apt-get install -y wireguard
+
+# Generate server keys
+wg genkey | tee /etc/wireguard/server_private.key | wg pubkey > /etc/wireguard/server_public.key
+chmod 600 /etc/wireguard/server_private.key
+
+# Get server private key
+SERVER_PRIVATE=$(cat /etc/wireguard/server_private.key)
+
+# Create WireGuard config
+cat > /etc/wireguard/wg0.conf << 'WGEOF'
+[Interface]
+Address = 10.0.0.1/24
+ListenPort = 51820
+PrivateKey = PRIVATE_KEY_PLACEHOLDER
+PostUp = iptables -A FORWARD -i wg0 -j ACCEPT; iptables -t nat -A POSTROUTING -o ens5 -j MASQUERADE; iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+PostDown = iptables -D FORWARD -i wg0 -j ACCEPT; iptables -t nat -D POSTROUTING -o ens5 -j MASQUERADE; iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE
+WGEOF
+
+# Replace placeholder with actual private key
+sed -i "s|PRIVATE_KEY_PLACEHOLDER|$SERVER_PRIVATE|g" /etc/wireguard/wg0.conf
+chmod 600 /etc/wireguard/wg0.conf
+
+# Enable IP forwarding
+echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf
+sysctl -p
+
+# Start WireGuard
+systemctl enable wg-quick@wg0
+systemctl start wg-quick@wg0
+
+# Output public key to a file and as an instance tag
+SERVER_PUBKEY=$(cat /etc/wireguard/server_public.key)
+echo "WIREGUARD_PUBKEY=$SERVER_PUBKEY" >> /var/log/wireguard-setup.log
+echo "WIREGUARD_READY=true" >> /var/log/wireguard-setup.log
+echo "WireGuard setup complete!"
+`
+	return script
+}
+
+// getLatestUbuntuAMI finds the latest Ubuntu 22.04 LTS AMI for the current region.
+func (p *Provider) getLatestUbuntuAMI(ctx context.Context) (string, error) {
+	// Search for official Ubuntu 22.04 LTS AMIs from Canonical
+	// Canonical's AWS account ID: 099720109477
+	result, err := p.ec2Client.DescribeImages(ctx, &ec2.DescribeImagesInput{
+		Owners: []string{"099720109477"}, // Canonical
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("name"),
+				Values: []string{"ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"},
+			},
+			{
+				Name:   aws.String("architecture"),
+				Values: []string{"x86_64"},
+			},
+			{
+				Name:   aws.String("virtualization-type"),
+				Values: []string{"hvm"},
+			},
+			{
+				Name:   aws.String("state"),
+				Values: []string{"available"},
+			},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to describe images: %w", err)
+	}
+
+	if len(result.Images) == 0 {
+		return "", fmt.Errorf("no Ubuntu 22.04 AMI found in region %s", p.region)
+	}
+
+	// Find the most recent image by creation date
+	var latestImage *types.Image
+	for i := range result.Images {
+		img := &result.Images[i]
+		if latestImage == nil || (img.CreationDate != nil && latestImage.CreationDate != nil &&
+			*img.CreationDate > *latestImage.CreationDate) {
+			latestImage = img
+		}
+	}
+
+	if latestImage == nil || latestImage.ImageId == nil {
+		return "", fmt.Errorf("no valid Ubuntu AMI found")
+	}
+
+	return *latestImage.ImageId, nil
+}
+
+// createKeyPair creates an EC2 key pair for SSH access to the instance.
+// Returns the key pair name. The private key is not stored as we use
+// user-data for configuration instead of SSH.
+func (p *Provider) createKeyPair(ctx context.Context) (string, error) {
+	keyName := fmt.Sprintf("my-own-vpn-%d", time.Now().Unix())
+
+	_, err := p.ec2Client.CreateKeyPair(ctx, &ec2.CreateKeyPairInput{
+		KeyName:           aws.String(keyName),
+		TagSpecifications: p.getTagSpecifications(types.ResourceTypeKeyPair),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create key pair: %w", err)
+	}
+
+	p.keyPairName = keyName
+	return keyName, nil
+}
+
+// deleteKeyPair deletes the EC2 key pair if it exists.
+func (p *Provider) deleteKeyPair(ctx context.Context) error {
+	if p.keyPairName == "" {
+		return nil
+	}
+
+	_, err := p.ec2Client.DeleteKeyPair(ctx, &ec2.DeleteKeyPairInput{
+		KeyName: aws.String(p.keyPairName),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete key pair: %w", err)
+	}
+
+	p.keyPairName = ""
+	return nil
+}
+
+// launchInstance launches an EC2 instance with WireGuard configured via user-data.
+func (p *Provider) launchInstance(ctx context.Context, instanceType string) error {
+	if p.subnetID == "" {
+		return fmt.Errorf("subnet must be created before launching instance")
+	}
+	if p.securityGroupID == "" {
+		return fmt.Errorf("security group must be created before launching instance")
+	}
+
+	// Get the latest Ubuntu AMI
+	amiID, err := p.getLatestUbuntuAMI(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Create key pair
+	keyName, err := p.createKeyPair(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Use default instance type if not specified
+	if instanceType == "" {
+		instanceType = defaultInstanceType
+	}
+
+	// Generate and encode user data
+	userData := base64.StdEncoding.EncodeToString([]byte(generateUserData()))
+
+	// Launch the instance
+	result, err := p.ec2Client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String(amiID),
+		InstanceType: types.InstanceType(instanceType),
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+		KeyName:      aws.String(keyName),
+		NetworkInterfaces: []types.InstanceNetworkInterfaceSpecification{
+			{
+				DeviceIndex:              aws.Int32(0),
+				SubnetId:                 aws.String(p.subnetID),
+				Groups:                   []string{p.securityGroupID},
+				AssociatePublicIpAddress: aws.Bool(true),
+			},
+		},
+		UserData:          aws.String(userData),
+		TagSpecifications: p.getTagSpecifications(types.ResourceTypeInstance),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to launch instance: %w", err)
+	}
+
+	if len(result.Instances) == 0 {
+		return fmt.Errorf("no instance was created")
+	}
+
+	p.instanceID = *result.Instances[0].InstanceId
+
+	return nil
+}
+
+// waitForInstanceRunning waits for the instance to reach the running state.
+func (p *Provider) waitForInstanceRunning(ctx context.Context) error {
+	if p.instanceID == "" {
+		return fmt.Errorf("no instance to wait for")
+	}
+
+	waiter := ec2.NewInstanceRunningWaiter(p.ec2Client)
+	err := waiter.Wait(ctx, &ec2.DescribeInstancesInput{
+		InstanceIds: []string{p.instanceID},
+	}, instanceWaitTimeout)
+	if err != nil {
+		return fmt.Errorf("failed waiting for instance to be running: %w", err)
+	}
+
+	return nil
+}
+
+// getInstancePublicIP retrieves the public IP address of the instance.
+func (p *Provider) getInstancePublicIP(ctx context.Context) (string, error) {
+	if p.instanceID == "" {
+		return "", fmt.Errorf("no instance ID")
+	}
+
+	result, err := p.ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		InstanceIds: []string{p.instanceID},
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to describe instance: %w", err)
+	}
+
+	if len(result.Reservations) == 0 || len(result.Reservations[0].Instances) == 0 {
+		return "", fmt.Errorf("instance not found")
+	}
+
+	instance := result.Reservations[0].Instances[0]
+	if instance.PublicIpAddress == nil {
+		return "", fmt.Errorf("instance has no public IP address")
+	}
+
+	return *instance.PublicIpAddress, nil
+}
+
+// waitForWireGuardReady polls the instance console output to check if WireGuard is ready.
+// This approach avoids the need for SSH access.
+func (p *Provider) waitForWireGuardReady(ctx context.Context) (string, error) {
+	if p.instanceID == "" {
+		return "", fmt.Errorf("no instance ID")
+	}
+
+	deadline := time.Now().Add(wireGuardReadyTimeout)
+
+	for time.Now().Before(deadline) {
+		// Check if context is cancelled
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		default:
+		}
+
+		// Get console output
+		output, err := p.ec2Client.GetConsoleOutput(ctx, &ec2.GetConsoleOutputInput{
+			InstanceId: aws.String(p.instanceID),
+		})
+		if err != nil {
+			// Console output may not be available immediately
+			time.Sleep(wireGuardPollInterval)
+			continue
+		}
+
+		if output.Output == nil {
+			time.Sleep(wireGuardPollInterval)
+			continue
+		}
+
+		// Decode the console output (it's base64 encoded)
+		decoded, err := base64.StdEncoding.DecodeString(*output.Output)
+		if err != nil {
+			time.Sleep(wireGuardPollInterval)
+			continue
+		}
+
+		consoleOutput := string(decoded)
+
+		// Check if WireGuard is ready
+		if strings.Contains(consoleOutput, "WIREGUARD_READY=true") {
+			// Extract the public key
+			pubKey := extractWireGuardPubKey(consoleOutput)
+			if pubKey != "" {
+				return pubKey, nil
+			}
+		}
+
+		time.Sleep(wireGuardPollInterval)
+	}
+
+	return "", fmt.Errorf("timeout waiting for WireGuard to be ready")
+}
+
+// extractWireGuardPubKey extracts the WireGuard public key from console output.
+func extractWireGuardPubKey(output string) string {
+	// Look for the line containing the public key
+	const prefix = "WIREGUARD_PUBKEY="
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, prefix) {
+			// Extract the key value
+			idx := strings.Index(line, prefix)
+			if idx >= 0 {
+				key := strings.TrimSpace(line[idx+len(prefix):])
+				// WireGuard public keys are 44 characters (base64 encoded 32 bytes)
+				if len(key) >= 44 {
+					return key[:44]
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// terminateInstance terminates the EC2 instance if it exists.
+func (p *Provider) terminateInstance(ctx context.Context) error {
+	if p.instanceID == "" {
+		return nil
+	}
+
+	_, err := p.ec2Client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
+		InstanceIds: []string{p.instanceID},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to terminate instance: %w", err)
+	}
+
+	// Wait for the instance to be terminated
+	waiter := ec2.NewInstanceTerminatedWaiter(p.ec2Client)
+	err = waiter.Wait(ctx, &ec2.DescribeInstancesInput{
+		InstanceIds: []string{p.instanceID},
+	}, instanceWaitTimeout)
+	if err != nil {
+		return fmt.Errorf("failed waiting for instance to terminate: %w", err)
+	}
+
+	p.instanceID = ""
+	return nil
+}
+
+// getInstanceState retrieves the current state of the EC2 instance.
+func (p *Provider) getInstanceState(ctx context.Context) (types.InstanceStateName, error) {
+	if p.instanceID == "" {
+		return "", ErrNotProvisioned
+	}
+
+	result, err := p.ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		InstanceIds: []string{p.instanceID},
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to describe instance: %w", err)
+	}
+
+	if len(result.Reservations) == 0 || len(result.Reservations[0].Instances) == 0 {
+		return "", fmt.Errorf("instance not found")
+	}
+
+	instance := result.Reservations[0].Instances[0]
+	if instance.State == nil {
+		return "", fmt.Errorf("instance state is nil")
+	}
+
+	return instance.State.Name, nil
+}
+
+// InstanceInfo contains information about the provisioned EC2 instance.
+type InstanceInfo struct {
+	InstanceID         string
+	PublicIP           string
+	State              types.InstanceStateName
+	WireGuardPublicKey string
+	KeyPairName        string
+}
+
+// GetInstanceInfo returns information about the provisioned EC2 instance.
+func (p *Provider) GetInstanceInfo() InstanceInfo {
+	return InstanceInfo{
+		InstanceID:  p.instanceID,
+		KeyPairName: p.keyPairName,
+	}
+}

--- a/internal/provider/aws/instance_test.go
+++ b/internal/provider/aws/instance_test.go
@@ -1,0 +1,363 @@
+package aws
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/gonfva/my-own-vpn/internal/provider"
+)
+
+func TestGenerateUserData(t *testing.T) {
+	userData := generateUserData()
+
+	// Check that the user data contains expected WireGuard setup commands
+	expectedContent := []string{
+		"#!/bin/bash",
+		"apt-get install -y wireguard",
+		"wg genkey",
+		"wg pubkey",
+		"/etc/wireguard/wg0.conf",
+		"ListenPort = 51820",
+		"net.ipv4.ip_forward=1",
+		"systemctl enable wg-quick@wg0",
+		"systemctl start wg-quick@wg0",
+		"WIREGUARD_READY=true",
+		"WIREGUARD_PUBKEY=",
+	}
+
+	for _, expected := range expectedContent {
+		if !contains(userData, expected) {
+			t.Errorf("user data does not contain expected content: %s", expected)
+		}
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func TestExtractWireGuardPubKey(t *testing.T) {
+	// WireGuard public keys are 44 characters (base64 encoded 32 bytes)
+	validKey := "abcdefghijklmnopqrstuvwxyz1234567890ABCDEF12"       // exactly 44 chars
+	keyWithExtra := "abcdefghijklmnopqrstuvwxyz1234567890ABCDEF12xx" // 46 chars
+
+	tests := []struct {
+		name     string
+		output   string
+		expected string
+	}{
+		{
+			name:     "valid public key",
+			output:   "some output\nWIREGUARD_PUBKEY=" + validKey + "\nmore output",
+			expected: validKey,
+		},
+		{
+			name:     "valid public key with extra characters",
+			output:   "WIREGUARD_PUBKEY=" + keyWithExtra,
+			expected: validKey, // Should extract first 44 chars
+		},
+		{
+			name:     "no public key",
+			output:   "some output without the key",
+			expected: "",
+		},
+		{
+			name:     "empty output",
+			output:   "",
+			expected: "",
+		},
+		{
+			name:     "key too short",
+			output:   "WIREGUARD_PUBKEY=short",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := extractWireGuardPubKey(tc.output)
+			if result != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestInstanceConstants(t *testing.T) {
+	// Verify constants have reasonable values
+	if defaultInstanceType != "t3.micro" {
+		t.Errorf("expected default instance type t3.micro, got %s", defaultInstanceType)
+	}
+
+	if instanceWaitTimeout <= 0 {
+		t.Error("instanceWaitTimeout should be positive")
+	}
+
+	if wireGuardReadyTimeout <= 0 {
+		t.Error("wireGuardReadyTimeout should be positive")
+	}
+
+	if wireGuardPollInterval <= 0 {
+		t.Error("wireGuardPollInterval should be positive")
+	}
+}
+
+func TestGetInstanceInfoEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	p, err := New(ctx, "test-access-key", "test-secret-key", "us-east-1")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	info := p.GetInstanceInfo()
+	if info.InstanceID != "" {
+		t.Errorf("expected empty instance ID, got %s", info.InstanceID)
+	}
+	if info.KeyPairName != "" {
+		t.Errorf("expected empty key pair name, got %s", info.KeyPairName)
+	}
+}
+
+func TestLaunchInstanceRequiresSubnet(t *testing.T) {
+	ctx := context.Background()
+
+	p, err := New(ctx, "test-access-key", "test-secret-key", "us-east-1")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	err = p.launchInstance(ctx, "t3.micro")
+	if err == nil {
+		t.Error("expected error when subnet is not created")
+	}
+}
+
+func TestLaunchInstanceRequiresSecurityGroup(t *testing.T) {
+	ctx := context.Background()
+
+	p, err := New(ctx, "test-access-key", "test-secret-key", "us-east-1")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	// Set subnet ID but not security group
+	p.subnetID = "subnet-12345"
+
+	err = p.launchInstance(ctx, "t3.micro")
+	if err == nil {
+		t.Error("expected error when security group is not created")
+	}
+}
+
+func TestTerminateInstanceEmptyIsNoop(t *testing.T) {
+	ctx := context.Background()
+
+	p, err := New(ctx, "test-access-key", "test-secret-key", "us-east-1")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	// Should not error when instance ID is empty
+	err = p.terminateInstance(ctx)
+	if err != nil {
+		t.Errorf("expected no error when terminating with empty instance ID, got: %v", err)
+	}
+}
+
+func TestDeleteKeyPairEmptyIsNoop(t *testing.T) {
+	ctx := context.Background()
+
+	p, err := New(ctx, "test-access-key", "test-secret-key", "us-east-1")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	// Should not error when key pair name is empty
+	err = p.deleteKeyPair(ctx)
+	if err != nil {
+		t.Errorf("expected no error when deleting with empty key pair name, got: %v", err)
+	}
+}
+
+func TestWaitForInstanceRunningNoInstance(t *testing.T) {
+	ctx := context.Background()
+
+	p, err := New(ctx, "test-access-key", "test-secret-key", "us-east-1")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	err = p.waitForInstanceRunning(ctx)
+	if err == nil {
+		t.Error("expected error when no instance exists")
+	}
+}
+
+func TestGetInstancePublicIPNoInstance(t *testing.T) {
+	ctx := context.Background()
+
+	p, err := New(ctx, "test-access-key", "test-secret-key", "us-east-1")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	_, err = p.getInstancePublicIP(ctx)
+	if err == nil {
+		t.Error("expected error when no instance exists")
+	}
+}
+
+func TestWaitForWireGuardReadyNoInstance(t *testing.T) {
+	ctx := context.Background()
+
+	p, err := New(ctx, "test-access-key", "test-secret-key", "us-east-1")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	_, err = p.waitForWireGuardReady(ctx)
+	if err == nil {
+		t.Error("expected error when no instance exists")
+	}
+}
+
+func TestGetInstanceStateNoInstance(t *testing.T) {
+	ctx := context.Background()
+
+	p, err := New(ctx, "test-access-key", "test-secret-key", "us-east-1")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	_, err = p.getInstanceState(ctx)
+	if err == nil {
+		t.Error("expected error when no instance exists")
+	}
+}
+
+// Integration test for full provision/deprovision cycle
+// This test requires valid AWS credentials and will create actual resources
+func TestProvisionAndDeprovisionIntegration(t *testing.T) {
+	accessKey := os.Getenv("TEST_AWS_ACCESS_KEY")
+	secretKey := os.Getenv("TEST_AWS_SECRET_KEY")
+	if accessKey == "" || secretKey == "" {
+		t.Skip("TEST_AWS_ACCESS_KEY and TEST_AWS_SECRET_KEY not set")
+	}
+
+	// Skip in short mode as this test takes several minutes
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	p, err := New(ctx, accessKey, secretKey, "us-east-1")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	// Ensure cleanup even if test fails
+	defer func() {
+		if p.instanceID != "" || p.vpcID != "" {
+			t.Log("Cleaning up resources...")
+			if cleanupErr := p.Deprovision(ctx); cleanupErr != nil {
+				t.Logf("Warning: cleanup failed: %v", cleanupErr)
+			}
+		}
+	}()
+
+	// Test provisioning
+	t.Log("Starting provision...")
+	serverInfo, err := p.Provision(ctx, provider.ProvisionConfig{
+		Region:       "us-east-1",
+		InstanceType: "t3.micro",
+	})
+	if err != nil {
+		t.Fatalf("Provision() returned error: %v", err)
+	}
+
+	// Verify server info
+	if serverInfo.PublicIP == "" {
+		t.Error("expected public IP, got empty string")
+	}
+	if serverInfo.WireGuardPort != wireGuardPort {
+		t.Errorf("expected WireGuard port %d, got %d", wireGuardPort, serverInfo.WireGuardPort)
+	}
+	if serverInfo.ServerPublicKey == "" {
+		t.Error("expected server public key, got empty string")
+	}
+	if len(serverInfo.ServerPublicKey) != 44 {
+		t.Errorf("expected public key length 44, got %d", len(serverInfo.ServerPublicKey))
+	}
+
+	t.Logf("Server provisioned: IP=%s, Key=%s", serverInfo.PublicIP, serverInfo.ServerPublicKey)
+
+	// Test GetStatus
+	status, err := p.GetStatus(ctx)
+	if err != nil {
+		t.Fatalf("GetStatus() returned error: %v", err)
+	}
+	if status.State != provider.StateRunning {
+		t.Errorf("expected state %s, got %s", provider.StateRunning, status.State)
+	}
+
+	// Test deprovisioning
+	t.Log("Starting deprovision...")
+	err = p.Deprovision(ctx)
+	if err != nil {
+		t.Fatalf("Deprovision() returned error: %v", err)
+	}
+
+	// Verify resources are cleaned up
+	if p.instanceID != "" {
+		t.Error("instance ID should be empty after deprovision")
+	}
+	if p.vpcID != "" {
+		t.Error("VPC ID should be empty after deprovision")
+	}
+
+	t.Log("Integration test completed successfully")
+}
+
+// Test for getting Ubuntu AMI
+func TestGetLatestUbuntuAMI(t *testing.T) {
+	accessKey := os.Getenv("TEST_AWS_ACCESS_KEY")
+	secretKey := os.Getenv("TEST_AWS_SECRET_KEY")
+	if accessKey == "" || secretKey == "" {
+		t.Skip("TEST_AWS_ACCESS_KEY and TEST_AWS_SECRET_KEY not set")
+	}
+
+	ctx := context.Background()
+
+	p, err := New(ctx, accessKey, secretKey, "us-east-1")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	amiID, err := p.getLatestUbuntuAMI(ctx)
+	if err != nil {
+		t.Fatalf("getLatestUbuntuAMI() returned error: %v", err)
+	}
+
+	if amiID == "" {
+		t.Error("expected AMI ID, got empty string")
+	}
+
+	// AWS AMI IDs start with "ami-"
+	if len(amiID) < 4 || amiID[:4] != "ami-" {
+		t.Errorf("expected AMI ID to start with 'ami-', got %s", amiID)
+	}
+
+	t.Logf("Found Ubuntu AMI: %s", amiID)
+}


### PR DESCRIPTION
## Summary

- Implements full EC2 instance provisioning workflow with WireGuard VPN server
- Server generates WireGuard keys on-instance via cloud-init user-data script
- Public key retrieved via EC2 console output (no SSH required)
- Complete infrastructure lifecycle: provision → running → deprovision

## Changes

- **instance.go**: New file with EC2 provisioning logic
  - `generateUserData()`: Cloud-init script for WireGuard installation
  - `getLatestUbuntuAMI()`: Finds Ubuntu 22.04 LTS AMI
  - `createKeyPair()`/`deleteKeyPair()`: EC2 key pair management
  - `launchInstance()`: Provisions EC2 with WireGuard configuration
  - `waitForWireGuardReady()`: Polls console output for public key
  - `terminateInstance()`: Cleans up EC2 instance
  - `getInstanceState()`: Returns current instance state

- **aws.go**: Updated main provider implementation
  - `Provision()`: Full orchestration of networking + instance + WireGuard setup
  - `Deprovision()`: Complete teardown of instance and networking
  - `GetStatus()`: Maps EC2 instance state to provider status

## Test plan

- [x] Unit tests pass (`go test -short ./internal/provider/aws/...`)
- [x] Linter passes (`golangci-lint run ./internal/provider/...`)
- [ ] Integration test (requires AWS credentials): `TEST_AWS_ACCESS_KEY=xxx TEST_AWS_SECRET_KEY=xxx go test -v ./internal/provider/aws/... -run Integration`

## Security considerations

- User data script contains no secrets (keys generated on-instance)
- WireGuard private key never leaves the EC2 instance
- No SSH access required after initial setup
- Security group limits access to WireGuard port (51820/UDP) only

🤖 Generated with [Claude Code](https://claude.com/claude-code)