### PR TITLE
feat: Implement platform-specific WireGuard tunnel management (#27)

### DIFF
--- a/internal/wireguard/client_darwin.go
+++ b/internal/wireguard/client_darwin.go
@@ -1,0 +1,143 @@
+//go:build darwin
+
+package wireguard
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+
+	"github.com/gonfva/my-own-vpn/internal/provider"
+)
+
+const (
+	tunnelNameDarwin = "my-own-vpn"
+	wgQuickCmd       = "wg-quick"
+	wgCmd            = "wg"
+	configDirDarwin  = "/etc/wireguard"
+)
+
+// darwinClient implements the Client interface for macOS using wg-quick.
+type darwinClient struct {
+	mu         sync.RWMutex
+	configPath string
+	keyPair    *KeyPair
+	serverIP   string
+	connected  bool
+}
+
+// NewClient creates a new WireGuard client for macOS.
+func NewClient() (Client, error) {
+	return &darwinClient{}, nil
+}
+
+// Connect establishes the VPN tunnel using wg-quick.
+// Note: This requires sudo privileges or the user to be in the appropriate group.
+func (c *darwinClient) Connect(ctx context.Context, serverInfo *provider.ServerInfo, clientKeyPair *KeyPair) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.connected {
+		return fmt.Errorf("already connected")
+	}
+
+	c.configPath = filepath.Join(configDirDarwin, tunnelNameDarwin+".conf")
+
+	// Generate configuration
+	config := DefaultConfig()
+	config.PrivateKey = clientKeyPair.PrivateKeyString()
+	config.ServerPublicKey = serverInfo.ServerPublicKey
+	config.ServerEndpoint = fmt.Sprintf("%s:%d", serverInfo.PublicIP, serverInfo.WireGuardPort)
+
+	// Write config file - this may require elevated privileges
+	if err := config.WriteToFile(c.configPath); err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	// Bring up the tunnel using wg-quick
+	// #nosec G204 - tunnelNameDarwin is a constant
+	cmd := exec.CommandContext(ctx, "sudo", wgQuickCmd, "up", tunnelNameDarwin)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// Clean up config file on failure
+		_ = os.Remove(c.configPath)
+		return fmt.Errorf("failed to bring up tunnel: %w, output: %s", err, string(output))
+	}
+
+	c.keyPair = clientKeyPair
+	c.serverIP = serverInfo.PublicIP
+	c.connected = true
+
+	return nil
+}
+
+// Disconnect tears down the VPN tunnel using wg-quick down.
+func (c *darwinClient) Disconnect(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if !c.connected {
+		return nil
+	}
+
+	// Bring down the tunnel
+	// #nosec G204 - tunnelNameDarwin is a constant
+	cmd := exec.CommandContext(ctx, "sudo", wgQuickCmd, "down", tunnelNameDarwin)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to bring down tunnel: %w, output: %s", err, string(output))
+	}
+
+	// Clean up config file
+	if c.configPath != "" {
+		_ = os.Remove(c.configPath)
+	}
+
+	c.connected = false
+	c.serverIP = ""
+
+	return nil
+}
+
+// Status returns the current connection status by querying wg show.
+func (c *darwinClient) Status() ConnectionStatus {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	status := ConnectionStatus{
+		Connected: c.connected,
+		ServerIP:  c.serverIP,
+	}
+
+	if !c.connected {
+		return status
+	}
+
+	// Query wg for detailed status
+	// #nosec G204 - tunnelNameDarwin is a constant
+	cmd := exec.Command("sudo", wgCmd, "show", tunnelNameDarwin)
+	output, err := cmd.Output()
+	if err != nil {
+		// If wg show fails, assume we're still connected but can't get stats
+		return status
+	}
+
+	// Parse wg show output
+	status.BytesSent, status.BytesReceived, status.LastHandshake = parseWgShowOutput(string(output))
+
+	return status
+}
+
+// GetPublicKey returns the client's public key.
+func (c *darwinClient) GetPublicKey() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.keyPair == nil {
+		return ""
+	}
+	return c.keyPair.PublicKeyString()
+}

--- a/internal/wireguard/client_other.go
+++ b/internal/wireguard/client_other.go
@@ -1,0 +1,21 @@
+//go:build !windows && !darwin
+
+package wireguard
+
+import (
+	"runtime"
+)
+
+// PlatformError indicates that the current platform is not supported.
+type PlatformError struct {
+	Platform string
+}
+
+func (e *PlatformError) Error() string {
+	return "wireguard client not supported on platform: " + e.Platform
+}
+
+// NewClient returns an error on unsupported platforms.
+func NewClient() (Client, error) {
+	return nil, &PlatformError{Platform: runtime.GOOS}
+}

--- a/internal/wireguard/client_windows.go
+++ b/internal/wireguard/client_windows.go
@@ -1,0 +1,168 @@
+//go:build windows
+
+package wireguard
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+
+	"github.com/gonfva/my-own-vpn/internal/provider"
+)
+
+const (
+	tunnelName     = "my-own-vpn"
+	wireguardExe   = "wireguard.exe"
+	wgExe          = "wg.exe"
+	configFileName = tunnelName + ".conf"
+)
+
+// windowsClient implements the Client interface for Windows using wireguard.exe CLI.
+type windowsClient struct {
+	mu         sync.RWMutex
+	configPath string
+	keyPair    *KeyPair
+	serverIP   string
+	connected  bool
+}
+
+// NewClient creates a new WireGuard client for Windows.
+func NewClient() (Client, error) {
+	return &windowsClient{}, nil
+}
+
+// Connect establishes the VPN tunnel using wireguard.exe.
+// It generates the configuration file and installs the tunnel service.
+func (c *windowsClient) Connect(ctx context.Context, serverInfo *provider.ServerInfo, clientKeyPair *KeyPair) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.connected {
+		return fmt.Errorf("already connected")
+	}
+
+	// Get config directory
+	configDir, err := c.getConfigDir()
+	if err != nil {
+		return fmt.Errorf("failed to get config directory: %w", err)
+	}
+
+	c.configPath = filepath.Join(configDir, configFileName)
+
+	// Generate and write configuration
+	config := DefaultConfig()
+	config.PrivateKey = clientKeyPair.PrivateKeyString()
+	config.ServerPublicKey = serverInfo.ServerPublicKey
+	config.ServerEndpoint = fmt.Sprintf("%s:%d", serverInfo.PublicIP, serverInfo.WireGuardPort)
+
+	if err := config.WriteToFile(c.configPath); err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	// Install tunnel service using wireguard.exe
+	// #nosec G204 - configPath is constructed from known safe components
+	cmd := exec.CommandContext(ctx, wireguardExe, "/installtunnelservice", c.configPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// Clean up config file on failure
+		_ = os.Remove(c.configPath)
+		return fmt.Errorf("failed to install tunnel service: %w, output: %s", err, string(output))
+	}
+
+	c.keyPair = clientKeyPair
+	c.serverIP = serverInfo.PublicIP
+	c.connected = true
+
+	return nil
+}
+
+// Disconnect tears down the VPN tunnel by uninstalling the tunnel service.
+func (c *windowsClient) Disconnect(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if !c.connected {
+		return nil
+	}
+
+	// Uninstall tunnel service
+	// #nosec G204 - tunnelName is a constant
+	cmd := exec.CommandContext(ctx, wireguardExe, "/uninstalltunnelservice", tunnelName)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to uninstall tunnel service: %w, output: %s", err, string(output))
+	}
+
+	// Clean up config file
+	if c.configPath != "" {
+		_ = os.Remove(c.configPath)
+	}
+
+	c.connected = false
+	c.serverIP = ""
+
+	return nil
+}
+
+// Status returns the current connection status by querying wg.exe.
+func (c *windowsClient) Status() ConnectionStatus {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	status := ConnectionStatus{
+		Connected: c.connected,
+		ServerIP:  c.serverIP,
+	}
+
+	if !c.connected {
+		return status
+	}
+
+	// Query wg.exe for detailed status
+	// #nosec G204 - tunnelName is a constant
+	cmd := exec.Command(wgExe, "show", tunnelName)
+	output, err := cmd.Output()
+	if err != nil {
+		// If wg show fails, assume we're still connected but can't get stats
+		return status
+	}
+
+	// Parse wg show output
+	status.BytesSent, status.BytesReceived, status.LastHandshake = parseWgShowOutput(string(output))
+
+	return status
+}
+
+// GetPublicKey returns the client's public key.
+func (c *windowsClient) GetPublicKey() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.keyPair == nil {
+		return ""
+	}
+	return c.keyPair.PublicKeyString()
+}
+
+// getConfigDir returns the directory where WireGuard configs should be stored.
+func (c *windowsClient) getConfigDir() (string, error) {
+	// On Windows, WireGuard looks for configs in %LOCALAPPDATA%\WireGuard\Configurations
+	// or we can specify the full path when installing the tunnel
+	localAppData := os.Getenv("LOCALAPPDATA")
+	if localAppData == "" {
+		return "", fmt.Errorf("LOCALAPPDATA environment variable not set")
+	}
+
+	configDir := filepath.Join(localAppData, "WireGuard", "Configurations")
+
+	// Create directory if it doesn't exist
+	// #nosec G301 - Configuration directory needs to be accessible
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		return "", fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	return configDir, nil
+}

--- a/internal/wireguard/parser.go
+++ b/internal/wireguard/parser.go
@@ -1,0 +1,142 @@
+package wireguard
+
+import (
+	"bufio"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// parseWgShowOutput parses the output of "wg show" command.
+// Example output:
+//
+//	interface: my-own-vpn
+//	  public key: <key>
+//	  private key: (hidden)
+//	  listening port: <port>
+//
+//	peer: <server-public-key>
+//	  endpoint: <ip>:<port>
+//	  allowed ips: 0.0.0.0/0, ::/0
+//	  latest handshake: 1 minute, 5 seconds ago
+//	  transfer: 1.23 MiB received, 456.78 KiB sent
+func parseWgShowOutput(output string) (bytesSent, bytesReceived uint64, lastHandshake time.Time) {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if strings.HasPrefix(line, "transfer:") {
+			bytesSent, bytesReceived = parseTransferLine(line)
+		} else if strings.HasPrefix(line, "latest handshake:") {
+			lastHandshake = parseHandshakeLine(line)
+		}
+	}
+
+	return bytesSent, bytesReceived, lastHandshake
+}
+
+// parseTransferLine parses a line like "transfer: 1.23 MiB received, 456.78 KiB sent"
+func parseTransferLine(line string) (sent, received uint64) {
+	// Remove prefix
+	line = strings.TrimPrefix(line, "transfer:")
+	line = strings.TrimSpace(line)
+
+	// Split by comma
+	parts := strings.Split(line, ",")
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if strings.HasSuffix(part, "received") {
+			received = parseBytes(strings.TrimSuffix(part, "received"))
+		} else if strings.HasSuffix(part, "sent") {
+			sent = parseBytes(strings.TrimSuffix(part, "sent"))
+		}
+	}
+
+	return sent, received
+}
+
+// parseBytes parses a string like "1.23 MiB" or "456.78 KiB" to bytes
+func parseBytes(s string) uint64 {
+	s = strings.TrimSpace(s)
+	parts := strings.Fields(s)
+	if len(parts) != 2 {
+		return 0
+	}
+
+	value, err := strconv.ParseFloat(parts[0], 64)
+	if err != nil {
+		return 0
+	}
+
+	unit := strings.ToLower(parts[1])
+	switch unit {
+	case "b":
+		return uint64(value)
+	case "kib":
+		return uint64(value * 1024)
+	case "mib":
+		return uint64(value * 1024 * 1024)
+	case "gib":
+		return uint64(value * 1024 * 1024 * 1024)
+	case "tib":
+		return uint64(value * 1024 * 1024 * 1024 * 1024)
+	default:
+		return 0
+	}
+}
+
+// parseHandshakeLine parses a line like "latest handshake: 1 minute, 5 seconds ago"
+func parseHandshakeLine(line string) time.Time {
+	line = strings.TrimPrefix(line, "latest handshake:")
+	line = strings.TrimSpace(line)
+	line = strings.TrimSuffix(line, "ago")
+	line = strings.TrimSpace(line)
+
+	if line == "" || line == "(none)" {
+		return time.Time{}
+	}
+
+	// Parse duration like "1 minute, 5 seconds" or "2 hours, 30 minutes, 45 seconds"
+	duration := parseDuration(line)
+	if duration == 0 {
+		return time.Time{}
+	}
+
+	return time.Now().Add(-duration)
+}
+
+// parseDuration parses a duration string like "1 minute, 5 seconds"
+func parseDuration(s string) time.Duration {
+	var total time.Duration
+
+	// Match patterns like "1 minute" or "5 seconds"
+	re := regexp.MustCompile(`(\d+)\s+(second|minute|hour|day)s?`)
+	matches := re.FindAllStringSubmatch(s, -1)
+
+	for _, match := range matches {
+		if len(match) != 3 {
+			continue
+		}
+
+		value, err := strconv.Atoi(match[1])
+		if err != nil {
+			continue
+		}
+
+		unit := match[2]
+		switch unit {
+		case "second":
+			total += time.Duration(value) * time.Second
+		case "minute":
+			total += time.Duration(value) * time.Minute
+		case "hour":
+			total += time.Duration(value) * time.Hour
+		case "day":
+			total += time.Duration(value) * 24 * time.Hour
+		}
+	}
+
+	return total
+}

--- a/internal/wireguard/parser_test.go
+++ b/internal/wireguard/parser_test.go
@@ -1,0 +1,329 @@
+package wireguard
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected uint64
+	}{
+		{
+			name:     "bytes",
+			input:    "100 B",
+			expected: 100,
+		},
+		{
+			name:     "kibibytes",
+			input:    "1 KiB",
+			expected: 1024,
+		},
+		{
+			name:     "mebibytes",
+			input:    "1 MiB",
+			expected: 1024 * 1024,
+		},
+		{
+			name:     "gibibytes",
+			input:    "1 GiB",
+			expected: 1024 * 1024 * 1024,
+		},
+		{
+			name:     "tebibytes",
+			input:    "1 TiB",
+			expected: 1024 * 1024 * 1024 * 1024,
+		},
+		{
+			name:     "fractional kibibytes",
+			input:    "1.5 KiB",
+			expected: 1536,
+		},
+		{
+			name:     "fractional mebibytes",
+			input:    "2.5 MiB",
+			expected: 2621440,
+		},
+		{
+			name:     "invalid format",
+			input:    "invalid",
+			expected: 0,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: 0,
+		},
+		{
+			name:     "unknown unit",
+			input:    "100 XB",
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseBytes(tt.input)
+			if result != tt.expected {
+				t.Errorf("parseBytes(%q) = %d, want %d", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected time.Duration
+	}{
+		{
+			name:     "seconds only",
+			input:    "30 seconds",
+			expected: 30 * time.Second,
+		},
+		{
+			name:     "single second",
+			input:    "1 second",
+			expected: 1 * time.Second,
+		},
+		{
+			name:     "minutes only",
+			input:    "5 minutes",
+			expected: 5 * time.Minute,
+		},
+		{
+			name:     "single minute",
+			input:    "1 minute",
+			expected: 1 * time.Minute,
+		},
+		{
+			name:     "hours only",
+			input:    "2 hours",
+			expected: 2 * time.Hour,
+		},
+		{
+			name:     "single hour",
+			input:    "1 hour",
+			expected: 1 * time.Hour,
+		},
+		{
+			name:     "days only",
+			input:    "3 days",
+			expected: 3 * 24 * time.Hour,
+		},
+		{
+			name:     "single day",
+			input:    "1 day",
+			expected: 24 * time.Hour,
+		},
+		{
+			name:     "minutes and seconds",
+			input:    "1 minute, 5 seconds",
+			expected: 1*time.Minute + 5*time.Second,
+		},
+		{
+			name:     "hours minutes and seconds",
+			input:    "2 hours, 30 minutes, 45 seconds",
+			expected: 2*time.Hour + 30*time.Minute + 45*time.Second,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: 0,
+		},
+		{
+			name:     "invalid format",
+			input:    "invalid",
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseDuration(tt.input)
+			if result != tt.expected {
+				t.Errorf("parseDuration(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseTransferLine(t *testing.T) {
+	tests := []struct {
+		name             string
+		input            string
+		expectedSent     uint64
+		expectedReceived uint64
+	}{
+		{
+			name:             "normal transfer line",
+			input:            "transfer: 1.23 MiB received, 456.78 KiB sent",
+			expectedSent:     467742,  // 456.78 * 1024
+			expectedReceived: 1289748, // 1.23 * 1024 * 1024
+		},
+		{
+			name:             "small transfer",
+			input:            "transfer: 100 B received, 50 B sent",
+			expectedSent:     50,
+			expectedReceived: 100,
+		},
+		{
+			name:             "large transfer",
+			input:            "transfer: 1 GiB received, 500 MiB sent",
+			expectedSent:     500 * 1024 * 1024,
+			expectedReceived: 1024 * 1024 * 1024,
+		},
+		{
+			name:             "empty line",
+			input:            "transfer:",
+			expectedSent:     0,
+			expectedReceived: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sent, received := parseTransferLine(tt.input)
+			if sent != tt.expectedSent {
+				t.Errorf("parseTransferLine(%q) sent = %d, want %d", tt.input, sent, tt.expectedSent)
+			}
+			if received != tt.expectedReceived {
+				t.Errorf("parseTransferLine(%q) received = %d, want %d", tt.input, received, tt.expectedReceived)
+			}
+		})
+	}
+}
+
+func TestParseHandshakeLine(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectZero  bool
+		minDuration time.Duration
+		maxDuration time.Duration
+	}{
+		{
+			name:        "recent handshake",
+			input:       "latest handshake: 30 seconds ago",
+			expectZero:  false,
+			minDuration: 29 * time.Second,
+			maxDuration: 31 * time.Second,
+		},
+		{
+			name:        "minute handshake",
+			input:       "latest handshake: 1 minute, 5 seconds ago",
+			expectZero:  false,
+			minDuration: 64 * time.Second,
+			maxDuration: 66 * time.Second,
+		},
+		{
+			name:       "no handshake",
+			input:      "latest handshake: (none)",
+			expectZero: true,
+		},
+		{
+			name:       "empty handshake",
+			input:      "latest handshake:",
+			expectZero: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseHandshakeLine(tt.input)
+			if tt.expectZero {
+				if !result.IsZero() {
+					t.Errorf("parseHandshakeLine(%q) = %v, want zero time", tt.input, result)
+				}
+			} else {
+				if result.IsZero() {
+					t.Errorf("parseHandshakeLine(%q) = zero time, want non-zero", tt.input)
+					return
+				}
+				elapsed := time.Since(result)
+				if elapsed < tt.minDuration || elapsed > tt.maxDuration {
+					t.Errorf("parseHandshakeLine(%q) elapsed = %v, want between %v and %v",
+						tt.input, elapsed, tt.minDuration, tt.maxDuration)
+				}
+			}
+		})
+	}
+}
+
+func TestParseWgShowOutput(t *testing.T) {
+	sampleOutput := `interface: my-own-vpn
+  public key: somepublickey123456789012345678901234567890==
+  private key: (hidden)
+  listening port: 51820
+
+peer: serverpublickey1234567890123456789012345678901234==
+  endpoint: 192.168.1.100:51820
+  allowed ips: 0.0.0.0/0, ::/0
+  latest handshake: 1 minute, 30 seconds ago
+  transfer: 10 MiB received, 5 MiB sent
+`
+
+	sent, received, handshake := parseWgShowOutput(sampleOutput)
+
+	expectedSent := uint64(5 * 1024 * 1024)
+	expectedReceived := uint64(10 * 1024 * 1024)
+
+	if sent != expectedSent {
+		t.Errorf("parseWgShowOutput sent = %d, want %d", sent, expectedSent)
+	}
+	if received != expectedReceived {
+		t.Errorf("parseWgShowOutput received = %d, want %d", received, expectedReceived)
+	}
+	if handshake.IsZero() {
+		t.Error("parseWgShowOutput handshake is zero, want non-zero")
+	}
+
+	// Handshake should be approximately 1 minute 30 seconds ago
+	elapsed := time.Since(handshake)
+	if elapsed < 89*time.Second || elapsed > 91*time.Second {
+		t.Errorf("parseWgShowOutput handshake elapsed = %v, want ~90 seconds", elapsed)
+	}
+}
+
+func TestParseWgShowOutputEmpty(t *testing.T) {
+	sent, received, handshake := parseWgShowOutput("")
+
+	if sent != 0 {
+		t.Errorf("parseWgShowOutput empty sent = %d, want 0", sent)
+	}
+	if received != 0 {
+		t.Errorf("parseWgShowOutput empty received = %d, want 0", received)
+	}
+	if !handshake.IsZero() {
+		t.Errorf("parseWgShowOutput empty handshake = %v, want zero", handshake)
+	}
+}
+
+func TestParseWgShowOutputNoHandshake(t *testing.T) {
+	sampleOutput := `interface: my-own-vpn
+  public key: somepublickey123456789012345678901234567890==
+  private key: (hidden)
+  listening port: 51820
+
+peer: serverpublickey1234567890123456789012345678901234==
+  endpoint: 192.168.1.100:51820
+  allowed ips: 0.0.0.0/0, ::/0
+  latest handshake: (none)
+  transfer: 0 B received, 0 B sent
+`
+
+	sent, received, handshake := parseWgShowOutput(sampleOutput)
+
+	if sent != 0 {
+		t.Errorf("parseWgShowOutput no handshake sent = %d, want 0", sent)
+	}
+	if received != 0 {
+		t.Errorf("parseWgShowOutput no handshake received = %d, want 0", received)
+	}
+	if !handshake.IsZero() {
+		t.Errorf("parseWgShowOutput no handshake handshake = %v, want zero", handshake)
+	}
+}


### PR DESCRIPTION
## Summary
- Implements Windows WireGuard client using `wireguard.exe` CLI (`/installtunnelservice`, `/uninstalltunnelservice`)
- Implements macOS WireGuard client using `wg-quick` (`up`/`down` commands with sudo)
- Adds stub for unsupported platforms that returns `PlatformError`
- Extracts shared `wg show` output parsing logic for connection status, transfer stats, and handshake timestamps

## Test plan
- [x] All existing tests pass
- [x] New parser tests pass (20 test cases covering bytes parsing, duration parsing, transfer line parsing, handshake parsing, and full wg show output parsing)
- [x] Linting passes for wireguard package
- [x] Cross-compilation verified for Windows and macOS
- [ ] Manual testing on Windows: Test connect/disconnect cycle (requires WireGuard installed)
- [ ] Manual testing on macOS: Test connect/disconnect cycle (requires wg-quick installed)

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)