### PR TITLE
feat: Implement Hetzner provider with WireGuard server (#23, #24)

### DIFF
--- a/internal/provider/hetzner/firewall.go
+++ b/internal/provider/hetzner/firewall.go
@@ -1,0 +1,80 @@
+package hetzner
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+// createFirewall creates a Hetzner Cloud firewall for the VPN server.
+// The firewall only allows inbound UDP traffic on the WireGuard port.
+func (p *Provider) createFirewall(ctx context.Context) error {
+	// Create firewall rules
+	// Allow inbound UDP 51820 (WireGuard)
+	rules := []hcloud.FirewallRule{
+		{
+			Direction: hcloud.FirewallRuleDirectionIn,
+			Protocol:  hcloud.FirewallRuleProtocolUDP,
+			Port:      hcloud.Ptr("51820"),
+			SourceIPs: []net.IPNet{
+				{IP: net.ParseIP("0.0.0.0"), Mask: net.CIDRMask(0, 32)}, // IPv4 any
+				{IP: net.ParseIP("::"), Mask: net.CIDRMask(0, 128)},     // IPv6 any
+			},
+			Description: hcloud.Ptr("Allow WireGuard UDP"),
+		},
+		// Allow inbound SSH for initial setup (retrieve WireGuard public key)
+		{
+			Direction: hcloud.FirewallRuleDirectionIn,
+			Protocol:  hcloud.FirewallRuleProtocolTCP,
+			Port:      hcloud.Ptr("22"),
+			SourceIPs: []net.IPNet{
+				{IP: net.ParseIP("0.0.0.0"), Mask: net.CIDRMask(0, 32)}, // IPv4 any
+				{IP: net.ParseIP("::"), Mask: net.CIDRMask(0, 128)},     // IPv6 any
+			},
+			Description: hcloud.Ptr("Allow SSH for setup"),
+		},
+	}
+
+	// Create the firewall
+	result, _, err := p.client.Firewall.Create(ctx, hcloud.FirewallCreateOpts{
+		Name:   fmt.Sprintf("my-own-vpn-%s", p.sessionID),
+		Rules:  rules,
+		Labels: p.getLabels(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create firewall: %w", err)
+	}
+
+	p.firewallID = result.Firewall.ID
+
+	// Wait for actions to complete
+	if len(result.Actions) > 0 {
+		if err := p.client.Action.WaitForFunc(ctx, nil, result.Actions...); err != nil {
+			return fmt.Errorf("failed waiting for firewall creation: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// deleteFirewall deletes the Hetzner Cloud firewall if it exists.
+func (p *Provider) deleteFirewall(ctx context.Context) error {
+	if p.firewallID == 0 {
+		return nil
+	}
+
+	_, err := p.client.Firewall.Delete(ctx, &hcloud.Firewall{ID: p.firewallID})
+	if err != nil {
+		// Check if already deleted
+		if hcloud.IsError(err, hcloud.ErrorCodeNotFound) {
+			p.firewallID = 0
+			return nil
+		}
+		return fmt.Errorf("failed to delete firewall: %w", err)
+	}
+
+	p.firewallID = 0
+	return nil
+}

--- a/internal/provider/hetzner/hetzner.go
+++ b/internal/provider/hetzner/hetzner.go
@@ -1,0 +1,330 @@
+// Package hetzner implements the cloud provider interface for Hetzner Cloud.
+package hetzner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gonfva/my-own-vpn/internal/provider"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+// Common errors returned by the Hetzner provider
+var (
+	ErrInvalidCredentials = errors.New("invalid Hetzner API token")
+	ErrNotProvisioned     = errors.New("no infrastructure provisioned")
+)
+
+// Provider implements the provider.Provider interface for Hetzner Cloud.
+type Provider struct {
+	client *hcloud.Client
+
+	// Session ID for labeling and identifying resources
+	sessionID string
+
+	// Track created resources for cleanup
+	serverID   int64
+	firewallID int64
+	sshKeyID   int64
+
+	// SSH key for server access (used to retrieve WireGuard public key)
+	sshKey *sshKeyPair
+
+	// Cached server info for GetStatus
+	serverPublicKey string
+	serverPublicIP  string
+}
+
+// New creates a new Hetzner provider with the given API token.
+func New(token string) (*Provider, error) {
+	if token == "" {
+		return nil, ErrInvalidCredentials
+	}
+
+	client := hcloud.NewClient(hcloud.WithToken(token))
+	return &Provider{
+		client: client,
+	}, nil
+}
+
+// ValidateCredentials verifies that the configured API token is valid
+// by calling the Datacenter List API.
+func (p *Provider) ValidateCredentials(ctx context.Context) error {
+	_, _, err := p.client.Datacenter.List(ctx, hcloud.DatacenterListOpts{})
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidCredentials, err)
+	}
+	return nil
+}
+
+// ListRegions returns the available Hetzner locations (datacenters).
+func (p *Provider) ListRegions(ctx context.Context) ([]provider.Region, error) {
+	locations, _, err := p.client.Location.List(ctx, hcloud.LocationListOpts{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list locations: %w", err)
+	}
+
+	regions := make([]provider.Region, 0, len(locations))
+	for _, loc := range locations {
+		regions = append(regions, provider.Region{
+			ID:   loc.Name,
+			Name: locationDisplayName(loc.Name, loc.City),
+		})
+	}
+
+	return regions, nil
+}
+
+// Provision creates all necessary Hetzner infrastructure for a VPN server.
+// It creates a firewall, SSH key, and server with WireGuard configured via cloud-init.
+func (p *Provider) Provision(ctx context.Context, cfg provider.ProvisionConfig) (*provider.ServerInfo, error) {
+	// Generate a unique session ID for this provisioning session
+	sessionID, err := generateSessionID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate session ID: %w", err)
+	}
+	p.sessionID = sessionID
+
+	// Step 1: Create firewall
+	if err := p.createFirewall(ctx); err != nil {
+		_ = p.deleteFirewall(ctx)
+		_ = clearState()
+		return nil, fmt.Errorf("failed to create firewall: %w", err)
+	}
+
+	// Save state after firewall is created
+	if err := p.saveState(); err != nil {
+		fmt.Printf("Warning: failed to save state: %v\n", err)
+	}
+
+	// Step 2: Create SSH key
+	if err := p.createSSHKey(ctx); err != nil {
+		_ = p.deleteSSHKey(ctx)
+		_ = p.deleteFirewall(ctx)
+		_ = clearState()
+		return nil, fmt.Errorf("failed to create SSH key: %w", err)
+	}
+
+	// Save state after SSH key is created
+	if err := p.saveState(); err != nil {
+		fmt.Printf("Warning: failed to save state: %v\n", err)
+	}
+
+	// Step 3: Create server with cloud-init
+	if err := p.createServer(ctx, cfg); err != nil {
+		_ = p.deleteServer(ctx)
+		_ = p.deleteSSHKey(ctx)
+		_ = p.deleteFirewall(ctx)
+		_ = clearState()
+		return nil, fmt.Errorf("failed to create server: %w", err)
+	}
+
+	// Save state after server is created
+	if err := p.saveState(); err != nil {
+		fmt.Printf("Warning: failed to save state: %v\n", err)
+	}
+
+	// Step 4: Wait for WireGuard to be ready and get the public key
+	pubKey, err := p.waitForWireGuardReady(ctx)
+	if err != nil {
+		_ = p.deleteServer(ctx)
+		_ = p.deleteSSHKey(ctx)
+		_ = p.deleteFirewall(ctx)
+		_ = clearState()
+		return nil, fmt.Errorf("failed waiting for WireGuard: %w", err)
+	}
+	p.serverPublicKey = pubKey
+
+	// Save final state
+	if err := p.saveState(); err != nil {
+		fmt.Printf("Warning: failed to save state: %v\n", err)
+	}
+
+	return &provider.ServerInfo{
+		PublicIP:        p.serverPublicIP,
+		WireGuardPort:   wireGuardPort,
+		ServerPublicKey: pubKey,
+	}, nil
+}
+
+// Deprovision tears down all Hetzner infrastructure created by Provision.
+func (p *Provider) Deprovision(ctx context.Context) error {
+	if p.serverID == 0 && p.firewallID == 0 && p.sshKeyID == 0 {
+		return ErrNotProvisioned
+	}
+
+	var errs []error
+
+	// Step 1: Delete server (must be done before firewall cleanup)
+	if err := p.deleteServer(ctx); err != nil {
+		errs = append(errs, fmt.Errorf("delete server: %w", err))
+	}
+
+	// Step 2: Delete SSH key
+	if err := p.deleteSSHKey(ctx); err != nil {
+		errs = append(errs, fmt.Errorf("delete SSH key: %w", err))
+	}
+
+	// Step 3: Delete firewall
+	if err := p.deleteFirewall(ctx); err != nil {
+		errs = append(errs, fmt.Errorf("delete firewall: %w", err))
+	}
+
+	// Clear cached server info
+	p.serverPublicKey = ""
+	p.serverPublicIP = ""
+	p.sessionID = ""
+
+	// Clear persisted state
+	if err := clearState(); err != nil {
+		errs = append(errs, fmt.Errorf("clear state: %w", err))
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to deprovision: %v", errs)
+	}
+
+	return nil
+}
+
+// GetStatus returns the current status of the provisioned infrastructure.
+func (p *Provider) GetStatus(ctx context.Context) (*provider.InfraStatus, error) {
+	if p.serverID == 0 {
+		return &provider.InfraStatus{
+			State:   provider.StateNotFound,
+			Message: "No infrastructure provisioned",
+		}, nil
+	}
+
+	// Get the server
+	server, _, err := p.client.Server.GetByID(ctx, p.serverID)
+	if err != nil {
+		return &provider.InfraStatus{
+			State:   provider.StateError,
+			Message: fmt.Sprintf("Failed to get server: %v", err),
+		}, nil
+	}
+
+	if server == nil {
+		return &provider.InfraStatus{
+			State:   provider.StateNotFound,
+			Message: "Server has been deleted",
+		}, nil
+	}
+
+	// Map Hetzner server status to InfraStatus
+	switch server.Status {
+	case hcloud.ServerStatusInitializing:
+		return &provider.InfraStatus{
+			State:   provider.StateProvisioning,
+			Message: "Server is initializing",
+		}, nil
+	case hcloud.ServerStatusStarting:
+		return &provider.InfraStatus{
+			State:   provider.StateProvisioning,
+			Message: "Server is starting",
+		}, nil
+	case hcloud.ServerStatusRunning:
+		return &provider.InfraStatus{
+			State:   provider.StateRunning,
+			Message: fmt.Sprintf("Server running at %s", p.serverPublicIP),
+		}, nil
+	case hcloud.ServerStatusStopping:
+		return &provider.InfraStatus{
+			State:   provider.StateStopped,
+			Message: "Server is stopping",
+		}, nil
+	case hcloud.ServerStatusOff:
+		return &provider.InfraStatus{
+			State:   provider.StateStopped,
+			Message: "Server is stopped",
+		}, nil
+	default:
+		return &provider.InfraStatus{
+			State:   provider.StateError,
+			Message: fmt.Sprintf("Unknown server status: %s", server.Status),
+		}, nil
+	}
+}
+
+// EstimateCost returns an estimate of the hourly cost for the given config.
+func (p *Provider) EstimateCost(cfg provider.ProvisionConfig) provider.CostEstimate {
+	// Hetzner pricing (EUR/month, converted to hourly USD approximation)
+	// CX11: ~3.29 EUR/month, CX21: ~5.83 EUR/month, CX31: ~10.59 EUR/month
+	// Using 730 hours/month and 1.1 EUR/USD conversion rate
+	costs := map[string]float64{
+		"cx11":  0.0050, // ~3.29 EUR/month
+		"cx21":  0.0088, // ~5.83 EUR/month
+		"cx31":  0.0159, // ~10.59 EUR/month
+		"cpx11": 0.0062, // ~4.15 EUR/month
+		"cpx21": 0.0106, // ~7.19 EUR/month
+		"cpx31": 0.0182, // ~12.49 EUR/month
+		"cax11": 0.0053, // ~3.29 EUR/month (ARM)
+		"cax21": 0.0088, // ~5.69 EUR/month (ARM)
+		"cax31": 0.0124, // ~8.09 EUR/month (ARM)
+	}
+
+	rate, ok := costs[cfg.InstanceType]
+	if !ok {
+		// Default to cx11 cost if instance type is unknown
+		rate = 0.0050
+	}
+
+	return provider.CostEstimate{
+		HourlyRate: rate,
+		Currency:   "USD",
+	}
+}
+
+// locationDisplayName returns a human-readable name for a Hetzner location.
+func locationDisplayName(locationID, city string) string {
+	names := map[string]string{
+		"fsn1": "Falkenstein, Germany",
+		"nbg1": "Nuremberg, Germany",
+		"hel1": "Helsinki, Finland",
+		"ash":  "Ashburn, USA",
+		"hil":  "Hillsboro, USA",
+	}
+
+	if name, ok := names[locationID]; ok {
+		return name
+	}
+	if city != "" {
+		return city
+	}
+	return locationID
+}
+
+// CleanupOrphaned finds and cleans up any orphaned resources that may have been
+// left behind due to a crash or improper shutdown.
+func (p *Provider) CleanupOrphaned(ctx context.Context) error {
+	// First, try to load state from disk
+	loaded, err := p.LoadExistingState()
+	if err != nil {
+		return fmt.Errorf("failed to load existing state: %w", err)
+	}
+
+	// If no state was loaded, try to find resources by labels
+	if !loaded {
+		if err := p.findResourcesByLabel(ctx); err != nil {
+			return fmt.Errorf("failed to find resources by label: %w", err)
+		}
+	}
+
+	// If no resources found, nothing to clean up
+	if !p.HasProvisionedResources() {
+		return nil
+	}
+
+	// Deprovision found resources
+	return p.Deprovision(ctx)
+}
+
+// GetSessionID returns the current session ID.
+func (p *Provider) GetSessionID() string {
+	return p.sessionID
+}
+
+// Ensure Provider implements provider.Provider at compile time
+var _ provider.Provider = (*Provider)(nil)

--- a/internal/provider/hetzner/hetzner_test.go
+++ b/internal/provider/hetzner/hetzner_test.go
@@ -1,0 +1,492 @@
+package hetzner
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/gonfva/my-own-vpn/internal/provider"
+)
+
+func TestNewProvider(t *testing.T) {
+	p, err := New("test-token")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("New() returned nil provider")
+	}
+	if p.client == nil {
+		t.Fatal("New() provider has nil client")
+	}
+}
+
+func TestNewProviderEmptyToken(t *testing.T) {
+	p, err := New("")
+	if err == nil {
+		t.Error("expected error for empty token")
+	}
+	if p != nil {
+		t.Error("expected nil provider for empty token")
+	}
+	if !errors.Is(err, ErrInvalidCredentials) {
+		t.Errorf("expected ErrInvalidCredentials, got: %v", err)
+	}
+}
+
+func TestValidateCredentialsInvalid(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	p, err := New("invalid-token")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	ctx := context.Background()
+	err = p.ValidateCredentials(ctx)
+	if err == nil {
+		t.Error("expected error for invalid credentials")
+	}
+	if !errors.Is(err, ErrInvalidCredentials) {
+		t.Errorf("expected ErrInvalidCredentials, got: %v", err)
+	}
+}
+
+func TestValidateCredentialsValid(t *testing.T) {
+	token := os.Getenv("TEST_HETZNER_TOKEN")
+	if token == "" {
+		t.Skip("TEST_HETZNER_TOKEN not set")
+	}
+
+	p, err := New(token)
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	ctx := context.Background()
+	err = p.ValidateCredentials(ctx)
+	if err != nil {
+		t.Errorf("ValidateCredentials() returned error: %v", err)
+	}
+}
+
+func TestListRegions(t *testing.T) {
+	token := os.Getenv("TEST_HETZNER_TOKEN")
+	if token == "" {
+		t.Skip("TEST_HETZNER_TOKEN not set")
+	}
+
+	p, err := New(token)
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	ctx := context.Background()
+	regions, err := p.ListRegions(ctx)
+	if err != nil {
+		t.Fatalf("ListRegions() returned error: %v", err)
+	}
+
+	if len(regions) == 0 {
+		t.Error("ListRegions() returned no regions")
+	}
+
+	// Check that fsn1 (Falkenstein) is in the list
+	found := false
+	for _, r := range regions {
+		if r.ID == "fsn1" {
+			found = true
+			if r.Name != "Falkenstein, Germany" {
+				t.Errorf("expected name 'Falkenstein, Germany', got %s", r.Name)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("fsn1 not found in regions list")
+	}
+}
+
+func TestProvisionFailsWithInvalidCredentials(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	p, err := New("invalid-token")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	ctx := context.Background()
+	// Provision should fail due to invalid credentials
+	_, err = p.Provision(ctx, provider.ProvisionConfig{
+		Region:       "fsn1",
+		InstanceType: "cx11",
+	})
+	if err == nil {
+		t.Error("expected error for invalid credentials during provision")
+	}
+}
+
+func TestDeprovisionNotProvisioned(t *testing.T) {
+	p, err := New("test-token")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	ctx := context.Background()
+	err = p.Deprovision(ctx)
+	if !errors.Is(err, ErrNotProvisioned) {
+		t.Errorf("expected ErrNotProvisioned, got: %v", err)
+	}
+}
+
+func TestGetStatusNotProvisioned(t *testing.T) {
+	p, err := New("test-token")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	ctx := context.Background()
+	status, err := p.GetStatus(ctx)
+	if err != nil {
+		t.Fatalf("GetStatus() returned error: %v", err)
+	}
+	if status.State != provider.StateNotFound {
+		t.Errorf("expected state %s, got %s", provider.StateNotFound, status.State)
+	}
+}
+
+func TestEstimateCost(t *testing.T) {
+	p, err := New("test-token")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	tests := []struct {
+		instanceType string
+		expectedRate float64
+	}{
+		{"cx11", 0.0050},
+		{"cx21", 0.0088},
+		{"cx31", 0.0159},
+		{"cpx11", 0.0062},
+		{"cax11", 0.0053},
+		{"unknown-type", 0.0050}, // defaults to cx11 rate
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.instanceType, func(t *testing.T) {
+			cost := p.EstimateCost(provider.ProvisionConfig{
+				Region:       "fsn1",
+				InstanceType: tc.instanceType,
+			})
+
+			if cost.HourlyRate != tc.expectedRate {
+				t.Errorf("expected rate %f, got %f", tc.expectedRate, cost.HourlyRate)
+			}
+			if cost.Currency != "USD" {
+				t.Errorf("expected currency USD, got %s", cost.Currency)
+			}
+		})
+	}
+}
+
+func TestLocationDisplayName(t *testing.T) {
+	tests := []struct {
+		locationID string
+		city       string
+		expected   string
+	}{
+		{"fsn1", "Falkenstein", "Falkenstein, Germany"},
+		{"nbg1", "Nuremberg", "Nuremberg, Germany"},
+		{"hel1", "Helsinki", "Helsinki, Finland"},
+		{"ash", "Ashburn", "Ashburn, USA"},
+		{"unknown-location", "Some City", "Some City"},
+		{"unknown-location", "", "unknown-location"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.locationID, func(t *testing.T) {
+			name := locationDisplayName(tc.locationID, tc.city)
+			if name != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, name)
+			}
+		})
+	}
+}
+
+func TestProviderImplementsInterface(t *testing.T) {
+	// This is a compile-time check, but we include it as a test for clarity
+	var _ provider.Provider = (*Provider)(nil)
+}
+
+func TestGetSessionID(t *testing.T) {
+	p, err := New("test-token")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	// Initially session ID should be empty
+	if p.GetSessionID() != "" {
+		t.Error("expected empty session ID initially")
+	}
+
+	// Set a session ID
+	p.sessionID = "test-session-12345678"
+
+	// Verify getter returns it
+	if p.GetSessionID() != "test-session-12345678" {
+		t.Errorf("expected session ID test-session-12345678, got %s", p.GetSessionID())
+	}
+}
+
+func TestHasProvisionedResources(t *testing.T) {
+	tests := []struct {
+		name       string
+		serverID   int64
+		firewallID int64
+		sshKeyID   int64
+		expected   bool
+	}{
+		{"no resources", 0, 0, 0, false},
+		{"server only", 123, 0, 0, true},
+		{"firewall only", 0, 456, 0, true},
+		{"ssh key only", 0, 0, 789, true},
+		{"all resources", 123, 456, 789, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := New("test-token")
+			if err != nil {
+				t.Fatalf("New() returned error: %v", err)
+			}
+			p.serverID = tc.serverID
+			p.firewallID = tc.firewallID
+			p.sshKeyID = tc.sshKeyID
+
+			if p.HasProvisionedResources() != tc.expected {
+				t.Errorf("expected HasProvisionedResources() to be %v", tc.expected)
+			}
+		})
+	}
+}
+
+func TestCleanupOrphanedNoResources(t *testing.T) {
+	// Ensure no state file exists
+	_ = clearState()
+
+	p, err := New("test-token")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	err = p.CleanupOrphaned(ctx)
+	// Error is expected because we have invalid credentials
+	if err == nil {
+		t.Log("CleanupOrphaned completed without error (no resources found)")
+	}
+}
+
+func TestCleanupOrphanedWithPersistedState(t *testing.T) {
+	// Create a provider and save some state
+	p1, err := New("test-token")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	p1.sessionID = "test-session"
+	p1.serverID = 12345
+	if err := p1.saveState(); err != nil {
+		t.Fatalf("saveState() returned error: %v", err)
+	}
+	defer func() { _ = clearState() }()
+
+	// Create a new provider
+	p2, err := New("test-token")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	// Verify the provider has no resources loaded initially
+	if p2.HasProvisionedResources() {
+		t.Error("expected no provisioned resources initially")
+	}
+
+	// Load existing state
+	loaded, err := p2.LoadExistingState()
+	if err != nil {
+		t.Fatalf("LoadExistingState() returned error: %v", err)
+	}
+	if !loaded {
+		t.Error("expected state to be loaded")
+	}
+
+	// Verify the state was restored
+	if p2.sessionID != "test-session" {
+		t.Errorf("expected session ID test-session, got %s", p2.sessionID)
+	}
+	if p2.serverID != 12345 {
+		t.Errorf("expected server ID 12345, got %d", p2.serverID)
+	}
+}
+
+func TestGenerateSessionID(t *testing.T) {
+	sessionID1, err := generateSessionID()
+	if err != nil {
+		t.Fatalf("generateSessionID() returned error: %v", err)
+	}
+
+	if len(sessionID1) != 16 {
+		t.Errorf("expected session ID length 16, got %d", len(sessionID1))
+	}
+
+	// Generate another and ensure they're different
+	sessionID2, err := generateSessionID()
+	if err != nil {
+		t.Fatalf("generateSessionID() returned error: %v", err)
+	}
+
+	if sessionID1 == sessionID2 {
+		t.Error("expected different session IDs")
+	}
+}
+
+func TestGetLabels(t *testing.T) {
+	p, err := New("test-token")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	// Without session ID
+	labels := p.getLabels()
+	if labels[labelKeyApplication] != labelValueApplication {
+		t.Errorf("expected application label %s, got %s", labelValueApplication, labels[labelKeyApplication])
+	}
+	if labels[labelKeyManagedBy] != labelValueApplication {
+		t.Errorf("expected managed-by label %s, got %s", labelValueApplication, labels[labelKeyManagedBy])
+	}
+	if _, ok := labels[labelKeySessionID]; ok {
+		t.Error("expected no session-id label when session ID is empty")
+	}
+
+	// With session ID
+	p.sessionID = "test-session-123"
+	labels = p.getLabels()
+	if labels[labelKeySessionID] != "test-session-123" {
+		t.Errorf("expected session-id label test-session-123, got %s", labels[labelKeySessionID])
+	}
+}
+
+func TestStatePersistence(t *testing.T) {
+	// Clean up any existing state
+	_ = clearState()
+	defer func() { _ = clearState() }()
+
+	p, err := New("test-token")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	// Set some state
+	p.sessionID = "test-session"
+	p.serverID = 111
+	p.firewallID = 222
+	p.sshKeyID = 333
+	p.serverPublicIP = "1.2.3.4"
+	p.serverPublicKey = "test-pubkey-12345678901234567890123456789012"
+
+	// Save state
+	if err := p.saveState(); err != nil {
+		t.Fatalf("saveState() returned error: %v", err)
+	}
+
+	// Load state
+	state, err := loadState()
+	if err != nil {
+		t.Fatalf("loadState() returned error: %v", err)
+	}
+	if state == nil {
+		t.Fatal("loadState() returned nil state")
+	}
+
+	// Verify state
+	if state.SessionID != "test-session" {
+		t.Errorf("expected session ID test-session, got %s", state.SessionID)
+	}
+	if state.ServerID != 111 {
+		t.Errorf("expected server ID 111, got %d", state.ServerID)
+	}
+	if state.FirewallID != 222 {
+		t.Errorf("expected firewall ID 222, got %d", state.FirewallID)
+	}
+	if state.SSHKeyID != 333 {
+		t.Errorf("expected SSH key ID 333, got %d", state.SSHKeyID)
+	}
+	if state.ServerPublicIP != "1.2.3.4" {
+		t.Errorf("expected server public IP 1.2.3.4, got %s", state.ServerPublicIP)
+	}
+	if state.ServerPublicKey != "test-pubkey-12345678901234567890123456789012" {
+		t.Errorf("expected server public key, got %s", state.ServerPublicKey)
+	}
+
+	// Clear state
+	if err := clearState(); err != nil {
+		t.Fatalf("clearState() returned error: %v", err)
+	}
+
+	// Verify state is cleared
+	state, err = loadState()
+	if err != nil {
+		t.Fatalf("loadState() after clear returned error: %v", err)
+	}
+	if state != nil {
+		t.Error("expected nil state after clear")
+	}
+}
+
+func TestRestoreFromState(t *testing.T) {
+	p, err := New("test-token")
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	state := &ProvisionState{
+		SessionID:       "test-session",
+		ServerID:        111,
+		FirewallID:      222,
+		SSHKeyID:        333,
+		ServerPublicIP:  "5.6.7.8",
+		ServerPublicKey: "test-pubkey",
+	}
+
+	p.restoreFromState(state)
+
+	if p.sessionID != "test-session" {
+		t.Errorf("expected session ID test-session, got %s", p.sessionID)
+	}
+	if p.serverID != 111 {
+		t.Errorf("expected server ID 111, got %d", p.serverID)
+	}
+	if p.firewallID != 222 {
+		t.Errorf("expected firewall ID 222, got %d", p.firewallID)
+	}
+	if p.sshKeyID != 333 {
+		t.Errorf("expected SSH key ID 333, got %d", p.sshKeyID)
+	}
+	if p.serverPublicIP != "5.6.7.8" {
+		t.Errorf("expected server public IP 5.6.7.8, got %s", p.serverPublicIP)
+	}
+	if p.serverPublicKey != "test-pubkey" {
+		t.Errorf("expected server public key test-pubkey, got %s", p.serverPublicKey)
+	}
+}

--- a/internal/provider/hetzner/server.go
+++ b/internal/provider/hetzner/server.go
@@ -1,0 +1,420 @@
+package hetzner
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gonfva/my-own-vpn/internal/provider"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"golang.org/x/crypto/ssh"
+)
+
+// Server constants
+const (
+	// defaultServerType is the default Hetzner server type
+	defaultServerType = "cx11"
+
+	// defaultImage is the Ubuntu image to use
+	defaultImage = "ubuntu-22.04"
+
+	// wireGuardPort is the UDP port for WireGuard
+	wireGuardPort = 51820
+
+	// wireGuardReadyTimeout is the maximum time to wait for WireGuard to be ready
+	wireGuardReadyTimeout = 5 * time.Minute
+
+	// wireGuardPollInterval is how often to check if WireGuard is ready
+	wireGuardPollInterval = 10 * time.Second
+
+	// serverReadyTimeout is the maximum time to wait for server to be running
+	serverReadyTimeout = 5 * time.Minute
+
+	// serverPollInterval is how often to check server status
+	serverPollInterval = 5 * time.Second
+)
+
+// generateUserData returns the cloud-init script to install and configure WireGuard.
+func generateUserData() string {
+	return `#!/bin/bash
+set -e
+
+# Log output for debugging
+exec > >(tee /var/log/wireguard-setup.log) 2>&1
+echo "Starting WireGuard setup..."
+
+# Install WireGuard
+apt-get update
+apt-get install -y wireguard
+
+# Generate server keys
+wg genkey | tee /etc/wireguard/server_private.key | wg pubkey > /etc/wireguard/server_public.key
+chmod 600 /etc/wireguard/server_private.key
+
+# Get server private key
+SERVER_PRIVATE=$(cat /etc/wireguard/server_private.key)
+
+# Get the primary network interface
+PRIMARY_IFACE=$(ip route | grep default | awk '{print $5}' | head -n1)
+
+# Create WireGuard config
+cat > /etc/wireguard/wg0.conf << WGEOF
+[Interface]
+Address = 10.0.0.1/24
+ListenPort = 51820
+PrivateKey = $SERVER_PRIVATE
+PostUp = iptables -A FORWARD -i wg0 -j ACCEPT; iptables -t nat -A POSTROUTING -o $PRIMARY_IFACE -j MASQUERADE
+PostDown = iptables -D FORWARD -i wg0 -j ACCEPT; iptables -t nat -D POSTROUTING -o $PRIMARY_IFACE -j MASQUERADE
+WGEOF
+
+chmod 600 /etc/wireguard/wg0.conf
+
+# Enable IP forwarding
+echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf
+sysctl -p
+
+# Start WireGuard
+systemctl enable wg-quick@wg0
+systemctl start wg-quick@wg0
+
+# Output public key for retrieval
+SERVER_PUBKEY=$(cat /etc/wireguard/server_public.key)
+echo "WIREGUARD_PUBKEY=$SERVER_PUBKEY"
+echo "WIREGUARD_READY=true"
+echo "WireGuard setup complete!"
+`
+}
+
+// sshKeyPair holds the generated SSH key pair
+type sshKeyPair struct {
+	privateKey []byte // PEM-encoded private key
+	publicKey  string // OpenSSH format public key
+	signer     ssh.Signer
+}
+
+// generateSSHKeyPair generates an Ed25519 SSH key pair for server access.
+func generateSSHKeyPair() (*sshKeyPair, error) {
+	// Generate Ed25519 key pair
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate Ed25519 key: %w", err)
+	}
+
+	// Convert to SSH public key
+	sshPubKey, err := ssh.NewPublicKey(pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SSH public key: %w", err)
+	}
+	publicKey := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(sshPubKey)))
+
+	// Convert private key to PEM format
+	privKeyBytes, err := ssh.MarshalPrivateKey(privKey, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal private key: %w", err)
+	}
+	privateKeyPEM := pem.EncodeToMemory(privKeyBytes)
+
+	// Create SSH signer
+	signer, err := ssh.NewSignerFromKey(privKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SSH signer: %w", err)
+	}
+
+	return &sshKeyPair{
+		privateKey: privateKeyPEM,
+		publicKey:  publicKey,
+		signer:     signer,
+	}, nil
+}
+
+// createSSHKey creates an SSH key in Hetzner Cloud for server access.
+// The private key is stored temporarily for retrieving the WireGuard public key.
+func (p *Provider) createSSHKey(ctx context.Context) error {
+	keyPair, err := generateSSHKeyPair()
+	if err != nil {
+		return err
+	}
+
+	keyName := fmt.Sprintf("my-own-vpn-%s", p.sessionID)
+
+	result, _, err := p.client.SSHKey.Create(ctx, hcloud.SSHKeyCreateOpts{
+		Name:      keyName,
+		PublicKey: keyPair.publicKey,
+		Labels:    p.getLabels(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create SSH key: %w", err)
+	}
+
+	p.sshKeyID = result.ID
+	p.sshKey = keyPair
+	return nil
+}
+
+// deleteSSHKey deletes the SSH key if it exists.
+func (p *Provider) deleteSSHKey(ctx context.Context) error {
+	if p.sshKeyID == 0 {
+		return nil
+	}
+
+	_, err := p.client.SSHKey.Delete(ctx, &hcloud.SSHKey{ID: p.sshKeyID})
+	if err != nil {
+		// Check if already deleted
+		if hcloud.IsError(err, hcloud.ErrorCodeNotFound) {
+			p.sshKeyID = 0
+			return nil
+		}
+		return fmt.Errorf("failed to delete SSH key: %w", err)
+	}
+
+	p.sshKeyID = 0
+	return nil
+}
+
+// createServer creates a Hetzner server with WireGuard configured via cloud-init.
+func (p *Provider) createServer(ctx context.Context, cfg provider.ProvisionConfig) error {
+	if p.sshKeyID == 0 {
+		return fmt.Errorf("SSH key must be created before creating server")
+	}
+
+	// Use default server type if not specified
+	serverType := cfg.InstanceType
+	if serverType == "" {
+		serverType = defaultServerType
+	}
+
+	// Use default location if not specified
+	location := cfg.Region
+	if location == "" {
+		location = "fsn1" // Falkenstein, Germany
+	}
+
+	// Get the server type
+	serverTypeObj, _, err := p.client.ServerType.GetByName(ctx, serverType)
+	if err != nil {
+		return fmt.Errorf("failed to get server type: %w", err)
+	}
+	if serverTypeObj == nil {
+		return fmt.Errorf("server type %s not found", serverType)
+	}
+
+	// Get the image
+	image, _, err := p.client.Image.GetByNameAndArchitecture(ctx, defaultImage, serverTypeObj.Architecture)
+	if err != nil {
+		return fmt.Errorf("failed to get image: %w", err)
+	}
+	if image == nil {
+		return fmt.Errorf("image %s not found for architecture %s", defaultImage, serverTypeObj.Architecture)
+	}
+
+	// Get the location
+	loc, _, err := p.client.Location.GetByName(ctx, location)
+	if err != nil {
+		return fmt.Errorf("failed to get location: %w", err)
+	}
+	if loc == nil {
+		return fmt.Errorf("location %s not found", location)
+	}
+
+	// Get the SSH key
+	sshKey, _, err := p.client.SSHKey.GetByID(ctx, p.sshKeyID)
+	if err != nil {
+		return fmt.Errorf("failed to get SSH key: %w", err)
+	}
+
+	// Get the firewall
+	var firewalls []*hcloud.ServerCreateFirewall
+	if p.firewallID != 0 {
+		firewalls = []*hcloud.ServerCreateFirewall{
+			{Firewall: hcloud.Firewall{ID: p.firewallID}},
+		}
+	}
+
+	// Create server
+	result, _, err := p.client.Server.Create(ctx, hcloud.ServerCreateOpts{
+		Name:       fmt.Sprintf("my-own-vpn-%s", p.sessionID),
+		ServerType: serverTypeObj,
+		Image:      image,
+		Location:   loc,
+		SSHKeys:    []*hcloud.SSHKey{sshKey},
+		Firewalls:  firewalls,
+		UserData:   generateUserData(),
+		Labels:     p.getLabels(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create server: %w", err)
+	}
+
+	p.serverID = result.Server.ID
+
+	// Wait for server action to complete
+	if result.Action != nil {
+		if err := p.client.Action.WaitForFunc(ctx, nil, result.Action); err != nil {
+			return fmt.Errorf("failed waiting for server creation: %w", err)
+		}
+	}
+
+	// Wait for server to be running
+	if err := p.waitForServerRunning(ctx); err != nil {
+		return err
+	}
+
+	// Get the server's public IP
+	server, _, err := p.client.Server.GetByID(ctx, p.serverID)
+	if err != nil {
+		return fmt.Errorf("failed to get server: %w", err)
+	}
+
+	if server.PublicNet.IPv4.IP != nil {
+		p.serverPublicIP = server.PublicNet.IPv4.IP.String()
+	} else {
+		return fmt.Errorf("server has no public IPv4 address")
+	}
+
+	return nil
+}
+
+// waitForServerRunning waits for the server to reach the running state.
+func (p *Provider) waitForServerRunning(ctx context.Context) error {
+	if p.serverID == 0 {
+		return fmt.Errorf("no server to wait for")
+	}
+
+	deadline := time.Now().Add(serverReadyTimeout)
+
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		server, _, err := p.client.Server.GetByID(ctx, p.serverID)
+		if err != nil {
+			time.Sleep(serverPollInterval)
+			continue
+		}
+
+		if server != nil && server.Status == hcloud.ServerStatusRunning {
+			return nil
+		}
+
+		time.Sleep(serverPollInterval)
+	}
+
+	return fmt.Errorf("timeout waiting for server to be running")
+}
+
+// waitForWireGuardReady waits for WireGuard to be ready by polling the server via SSH.
+// Since Hetzner doesn't provide a console output API like AWS, we use SSH to check.
+func (p *Provider) waitForWireGuardReady(ctx context.Context) (string, error) {
+	if p.serverID == 0 {
+		return "", fmt.Errorf("no server ID")
+	}
+
+	if p.serverPublicIP == "" {
+		return "", fmt.Errorf("server IP not available")
+	}
+
+	deadline := time.Now().Add(wireGuardReadyTimeout)
+
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		default:
+		}
+
+		// Try to retrieve the WireGuard public key via SSH
+		pubKey, err := p.retrievePublicKeyViaSSH(ctx)
+		if err == nil && pubKey != "" {
+			return pubKey, nil
+		}
+
+		time.Sleep(wireGuardPollInterval)
+	}
+
+	return "", fmt.Errorf("timeout waiting for WireGuard to be ready")
+}
+
+// retrievePublicKeyViaSSH connects to the server via SSH to retrieve the WireGuard public key.
+func (p *Provider) retrievePublicKeyViaSSH(ctx context.Context) (string, error) {
+	if p.sshKey == nil || p.sshKey.signer == nil {
+		return "", fmt.Errorf("SSH key not available")
+	}
+
+	if p.serverPublicIP == "" {
+		return "", fmt.Errorf("server IP not available")
+	}
+
+	// SSH configuration
+	config := &ssh.ClientConfig{
+		User: "root",
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(p.sshKey.signer),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), // #nosec G106 - acceptable for ephemeral VPN servers
+		Timeout:         30 * time.Second,
+	}
+
+	// Connect to server
+	addr := fmt.Sprintf("%s:22", p.serverPublicIP)
+	client, err := ssh.Dial("tcp", addr, config)
+	if err != nil {
+		return "", fmt.Errorf("failed to dial SSH: %w", err)
+	}
+	defer client.Close()
+
+	// Create a session
+	session, err := client.NewSession()
+	if err != nil {
+		return "", fmt.Errorf("failed to create SSH session: %w", err)
+	}
+	defer session.Close()
+
+	// Run the command to get the WireGuard public key
+	output, err := session.CombinedOutput("cat /etc/wireguard/server_public.key 2>/dev/null")
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve WireGuard public key: %w", err)
+	}
+
+	pubKey := strings.TrimSpace(string(output))
+	if len(pubKey) != 44 { // WireGuard public keys are 44 characters (base64 encoded 32 bytes)
+		return "", fmt.Errorf("invalid WireGuard public key length: %d", len(pubKey))
+	}
+
+	return pubKey, nil
+}
+
+// deleteServer deletes the Hetzner server if it exists.
+func (p *Provider) deleteServer(ctx context.Context) error {
+	if p.serverID == 0 {
+		return nil
+	}
+
+	result, _, err := p.client.Server.DeleteWithResult(ctx, &hcloud.Server{ID: p.serverID})
+	if err != nil {
+		// Check if already deleted
+		if hcloud.IsError(err, hcloud.ErrorCodeNotFound) {
+			p.serverID = 0
+			p.serverPublicIP = ""
+			return nil
+		}
+		return fmt.Errorf("failed to delete server: %w", err)
+	}
+
+	// Wait for deletion to complete
+	if result.Action != nil {
+		if err := p.client.Action.WaitForFunc(ctx, nil, result.Action); err != nil {
+			return fmt.Errorf("failed waiting for server deletion: %w", err)
+		}
+	}
+
+	p.serverID = 0
+	p.serverPublicIP = ""
+	return nil
+}

--- a/internal/provider/hetzner/server_test.go
+++ b/internal/provider/hetzner/server_test.go
@@ -1,0 +1,87 @@
+package hetzner
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateSSHKeyPair(t *testing.T) {
+	keyPair, err := generateSSHKeyPair()
+	if err != nil {
+		t.Fatalf("generateSSHKeyPair() returned error: %v", err)
+	}
+
+	if keyPair == nil {
+		t.Fatal("generateSSHKeyPair() returned nil")
+	}
+
+	// Check private key is PEM encoded
+	if len(keyPair.privateKey) == 0 {
+		t.Error("private key is empty")
+	}
+	if !strings.Contains(string(keyPair.privateKey), "-----BEGIN OPENSSH PRIVATE KEY-----") {
+		t.Error("private key is not in PEM format")
+	}
+
+	// Check public key is in OpenSSH format
+	if len(keyPair.publicKey) == 0 {
+		t.Error("public key is empty")
+	}
+	if !strings.HasPrefix(keyPair.publicKey, "ssh-ed25519 ") {
+		t.Error("public key is not in OpenSSH format")
+	}
+
+	// Check signer is available
+	if keyPair.signer == nil {
+		t.Error("signer is nil")
+	}
+}
+
+func TestGenerateSSHKeyPairUniqueness(t *testing.T) {
+	keyPair1, err := generateSSHKeyPair()
+	if err != nil {
+		t.Fatalf("generateSSHKeyPair() returned error: %v", err)
+	}
+
+	keyPair2, err := generateSSHKeyPair()
+	if err != nil {
+		t.Fatalf("generateSSHKeyPair() returned error: %v", err)
+	}
+
+	if keyPair1.publicKey == keyPair2.publicKey {
+		t.Error("expected different public keys")
+	}
+
+	if string(keyPair1.privateKey) == string(keyPair2.privateKey) {
+		t.Error("expected different private keys")
+	}
+}
+
+func TestGenerateUserData(t *testing.T) {
+	userData := generateUserData()
+
+	if len(userData) == 0 {
+		t.Error("user data is empty")
+	}
+
+	// Check for expected content
+	expectedContents := []string{
+		"#!/bin/bash",
+		"apt-get install -y wireguard",
+		"wg genkey",
+		"/etc/wireguard/wg0.conf",
+		"Address = 10.0.0.1/24",
+		"ListenPort = 51820",
+		"WIREGUARD_PUBKEY=",
+		"WIREGUARD_READY=true",
+		"systemctl enable wg-quick@wg0",
+		"systemctl start wg-quick@wg0",
+		"net.ipv4.ip_forward=1",
+	}
+
+	for _, expected := range expectedContents {
+		if !strings.Contains(userData, expected) {
+			t.Errorf("user data missing expected content: %s", expected)
+		}
+	}
+}

--- a/internal/provider/hetzner/state.go
+++ b/internal/provider/hetzner/state.go
@@ -1,0 +1,231 @@
+package hetzner
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+// ProvisionState stores the IDs of all provisioned resources for crash recovery.
+// This state is persisted to disk so resources can be cleaned up even after app restart.
+type ProvisionState struct {
+	SessionID       string `json:"session_id"`
+	ServerID        int64  `json:"server_id,omitempty"`
+	FirewallID      int64  `json:"firewall_id,omitempty"`
+	SSHKeyID        int64  `json:"ssh_key_id,omitempty"`
+	ServerPublicIP  string `json:"server_public_ip,omitempty"`
+	ServerPublicKey string `json:"server_public_key,omitempty"`
+}
+
+const (
+	// stateFileName is the name of the state file
+	stateFileName = "hetzner_provision_state.json"
+
+	// labelKeyApplication is the label key for application identification
+	labelKeyApplication = "application"
+
+	// labelKeyManagedBy is the label key for management identification
+	labelKeyManagedBy = "managed-by"
+
+	// labelKeySessionID is the label key for session identification
+	labelKeySessionID = "session-id"
+
+	// labelValueApplication is the value for the Application label
+	labelValueApplication = "my-own-vpn"
+)
+
+// generateSessionID creates a unique session identifier.
+func generateSessionID() (string, error) {
+	bytes := make([]byte, 8)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", fmt.Errorf("failed to generate session ID: %w", err)
+	}
+	return hex.EncodeToString(bytes), nil
+}
+
+// getLabels returns the standard labels applied to all resources.
+func (p *Provider) getLabels() map[string]string {
+	labels := map[string]string{
+		labelKeyApplication: labelValueApplication,
+		labelKeyManagedBy:   labelValueApplication,
+	}
+
+	if p.sessionID != "" {
+		labels[labelKeySessionID] = p.sessionID
+	}
+
+	return labels
+}
+
+// getStateFilePath returns the path to the state file.
+// It uses the user's config directory to store the state.
+func getStateFilePath() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get config directory: %w", err)
+	}
+
+	appDir := filepath.Clean(filepath.Join(configDir, "my-own-vpn"))
+	if err := os.MkdirAll(appDir, 0o700); err != nil { // #nosec G301 - intentional directory permissions
+		return "", fmt.Errorf("failed to create app directory: %w", err)
+	}
+
+	return filepath.Clean(filepath.Join(appDir, stateFileName)), nil
+}
+
+// saveState persists the current provision state to disk.
+func (p *Provider) saveState() error {
+	state := ProvisionState{
+		SessionID:       p.sessionID,
+		ServerID:        p.serverID,
+		FirewallID:      p.firewallID,
+		SSHKeyID:        p.sshKeyID,
+		ServerPublicIP:  p.serverPublicIP,
+		ServerPublicKey: p.serverPublicKey,
+	}
+
+	filePath, err := getStateFilePath()
+	if err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal state: %w", err)
+	}
+
+	if err := os.WriteFile(filePath, data, 0o600); err != nil { // #nosec G306 - intentional file permissions
+		return fmt.Errorf("failed to write state file: %w", err)
+	}
+
+	return nil
+}
+
+// loadState loads the provision state from disk if it exists.
+func loadState() (*ProvisionState, error) {
+	filePath, err := getStateFilePath()
+	if err != nil {
+		return nil, err
+	}
+
+	// #nosec G304 - filePath is constructed from system config dir and a hardcoded constant
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // No state file exists
+		}
+		return nil, fmt.Errorf("failed to read state file: %w", err)
+	}
+
+	var state ProvisionState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal state: %w", err)
+	}
+
+	return &state, nil
+}
+
+// clearState removes the state file from disk.
+func clearState() error {
+	filePath, err := getStateFilePath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.Remove(filePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove state file: %w", err)
+	}
+
+	return nil
+}
+
+// restoreFromState restores the provider's internal state from a ProvisionState.
+func (p *Provider) restoreFromState(state *ProvisionState) {
+	p.sessionID = state.SessionID
+	p.serverID = state.ServerID
+	p.firewallID = state.FirewallID
+	p.sshKeyID = state.SSHKeyID
+	p.serverPublicIP = state.ServerPublicIP
+	p.serverPublicKey = state.ServerPublicKey
+}
+
+// findResourcesByLabel discovers existing resources created by this application
+// using the managed-by label. This allows cleanup of orphaned resources.
+func (p *Provider) findResourcesByLabel(ctx context.Context) error {
+	labelSelector := fmt.Sprintf("%s=%s", labelKeyManagedBy, labelValueApplication)
+
+	// Find Servers
+	servers, _, err := p.client.Server.List(ctx, hcloud.ServerListOpts{
+		ListOpts: hcloud.ListOpts{
+			LabelSelector: labelSelector,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list servers: %w", err)
+	}
+	if len(servers) > 0 {
+		p.serverID = servers[0].ID
+		if servers[0].PublicNet.IPv4.IP != nil {
+			p.serverPublicIP = servers[0].PublicNet.IPv4.IP.String()
+		}
+		// Extract session ID from labels if available
+		if sessionID, ok := servers[0].Labels[labelKeySessionID]; ok {
+			p.sessionID = sessionID
+		}
+	}
+
+	// Find Firewalls
+	firewalls, _, err := p.client.Firewall.List(ctx, hcloud.FirewallListOpts{
+		ListOpts: hcloud.ListOpts{
+			LabelSelector: labelSelector,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list firewalls: %w", err)
+	}
+	if len(firewalls) > 0 {
+		p.firewallID = firewalls[0].ID
+	}
+
+	// Find SSH Keys
+	sshKeys, _, err := p.client.SSHKey.List(ctx, hcloud.SSHKeyListOpts{
+		ListOpts: hcloud.ListOpts{
+			LabelSelector: labelSelector,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list SSH keys: %w", err)
+	}
+	if len(sshKeys) > 0 {
+		p.sshKeyID = sshKeys[0].ID
+	}
+
+	return nil
+}
+
+// HasProvisionedResources checks if there are any provisioned resources
+// either in memory or persisted in the state file.
+func (p *Provider) HasProvisionedResources() bool {
+	return p.serverID != 0 || p.firewallID != 0 || p.sshKeyID != 0
+}
+
+// LoadExistingState attempts to load existing state from disk and restore it.
+// Returns true if state was found and loaded.
+func (p *Provider) LoadExistingState() (bool, error) {
+	state, err := loadState()
+	if err != nil {
+		return false, err
+	}
+	if state == nil {
+		return false, nil
+	}
+
+	p.restoreFromState(state)
+	return true, nil
+}


### PR DESCRIPTION
## Summary
- Implements the Hetzner Cloud provider for provisioning VPN infrastructure
- Completes tickets #23 (Epic: Hetzner Provider) and #24 (Implement Hetzner provider with WireGuard server)
- Server provisioning with WireGuard via cloud-init
- Firewall, SSH key management, state persistence, and crash recovery

## Changes
- `internal/provider/hetzner/hetzner.go` - Main provider implementation with Provider interface
- `internal/provider/hetzner/server.go` - Server provisioning, SSH key generation, cloud-init
- `internal/provider/hetzner/firewall.go` - Firewall rules for WireGuard and SSH
- `internal/provider/hetzner/state.go` - State persistence and resource discovery
- `internal/provider/hetzner/hetzner_test.go` - Comprehensive tests
- `internal/provider/hetzner/server_test.go` - Tests for SSH key and cloud-init generation

## Test plan
- [x] All unit tests pass (`go test -short ./internal/provider/hetzner/...`)
- [x] Linter passes (`golangci-lint run ./internal/provider/hetzner/...`)
- [ ] Integration tests with real Hetzner API (requires TEST_HETZNER_TOKEN env var)
- [ ] End-to-end test: provision server, retrieve WireGuard key, deprovision

## Notes
The implementation follows the existing AWS provider patterns but is simpler since Hetzner doesn't require VPC/networking setup. SSH-based key retrieval is used instead of console output polling (which Hetzner doesn't support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)