### PR TITLE
feat: Implement cost estimation and real-time display (#29)

### DIFF
--- a/internal/cost/pricing.go
+++ b/internal/cost/pricing.go
@@ -1,0 +1,186 @@
+package cost
+
+// Pricing data for AWS and Hetzner cloud providers.
+// These are approximate hourly rates and may change over time.
+// Note: Costs are estimates and actual billing may vary.
+
+// AWSPricing contains hourly rates (USD) for AWS EC2 instances by region.
+// Rates are for on-demand Linux instances.
+var AWSPricing = map[string]map[string]float64{
+	"t3.nano": {
+		"us-east-1":      0.0052,
+		"us-east-2":      0.0052,
+		"us-west-1":      0.0062,
+		"us-west-2":      0.0052,
+		"eu-west-1":      0.0059,
+		"eu-west-2":      0.0062,
+		"eu-central-1":   0.0060,
+		"ap-northeast-1": 0.0068,
+		"ap-southeast-1": 0.0059,
+		"ap-southeast-2": 0.0066,
+	},
+	"t3.micro": {
+		"us-east-1":      0.0104,
+		"us-east-2":      0.0104,
+		"us-west-1":      0.0124,
+		"us-west-2":      0.0104,
+		"eu-west-1":      0.0116,
+		"eu-west-2":      0.0124,
+		"eu-central-1":   0.0118,
+		"ap-northeast-1": 0.0136,
+		"ap-southeast-1": 0.0118,
+		"ap-southeast-2": 0.0132,
+	},
+	"t3.small": {
+		"us-east-1":      0.0208,
+		"us-east-2":      0.0208,
+		"us-west-1":      0.0248,
+		"us-west-2":      0.0208,
+		"eu-west-1":      0.0232,
+		"eu-west-2":      0.0248,
+		"eu-central-1":   0.0236,
+		"ap-northeast-1": 0.0272,
+		"ap-southeast-1": 0.0236,
+		"ap-southeast-2": 0.0264,
+	},
+	"t3.medium": {
+		"us-east-1":      0.0416,
+		"us-east-2":      0.0416,
+		"us-west-1":      0.0496,
+		"us-west-2":      0.0416,
+		"eu-west-1":      0.0464,
+		"eu-west-2":      0.0496,
+		"eu-central-1":   0.0472,
+		"ap-northeast-1": 0.0544,
+		"ap-southeast-1": 0.0472,
+		"ap-southeast-2": 0.0528,
+	},
+	"t2.micro": {
+		"us-east-1":      0.0116,
+		"us-east-2":      0.0116,
+		"us-west-1":      0.0140,
+		"us-west-2":      0.0116,
+		"eu-west-1":      0.0134,
+		"eu-west-2":      0.0140,
+		"eu-central-1":   0.0134,
+		"ap-northeast-1": 0.0152,
+		"ap-southeast-1": 0.0134,
+		"ap-southeast-2": 0.0148,
+	},
+	"t2.small": {
+		"us-east-1":      0.0230,
+		"us-east-2":      0.0230,
+		"us-west-1":      0.0276,
+		"us-west-2":      0.0230,
+		"eu-west-1":      0.0268,
+		"eu-west-2":      0.0276,
+		"eu-central-1":   0.0268,
+		"ap-northeast-1": 0.0304,
+		"ap-southeast-1": 0.0268,
+		"ap-southeast-2": 0.0296,
+	},
+	"t2.medium": {
+		"us-east-1":      0.0464,
+		"us-east-2":      0.0464,
+		"us-west-1":      0.0556,
+		"us-west-2":      0.0464,
+		"eu-west-1":      0.0536,
+		"eu-west-2":      0.0556,
+		"eu-central-1":   0.0536,
+		"ap-northeast-1": 0.0608,
+		"ap-southeast-1": 0.0536,
+		"ap-southeast-2": 0.0592,
+	},
+}
+
+// HetznerPricing contains hourly rates (USD) for Hetzner cloud servers.
+// Rates are converted from EUR monthly pricing to hourly USD approximation.
+// Hetzner pricing is the same across all locations.
+var HetznerPricing = map[string]float64{
+	// Shared vCPU (Intel)
+	"cx11": 0.0050, // ~3.29 EUR/month
+	"cx21": 0.0088, // ~5.83 EUR/month
+	"cx31": 0.0159, // ~10.59 EUR/month
+	"cx41": 0.0269, // ~17.49 EUR/month
+	"cx51": 0.0508, // ~32.99 EUR/month
+
+	// Shared vCPU (AMD, high-performance)
+	"cpx11": 0.0066, // ~4.49 EUR/month
+	"cpx21": 0.0119, // ~8.49 EUR/month
+	"cpx31": 0.0208, // ~14.99 EUR/month
+	"cpx41": 0.0357, // ~26.49 EUR/month
+	"cpx51": 0.0700, // ~52.99 EUR/month
+
+	// ARM (Ampere)
+	"cax11": 0.0053, // ~3.79 EUR/month
+	"cax21": 0.0092, // ~6.49 EUR/month
+	"cax31": 0.0166, // ~11.99 EUR/month
+	"cax41": 0.0285, // ~20.49 EUR/month
+}
+
+// DefaultAWSInstanceType is the default instance type for AWS.
+const DefaultAWSInstanceType = "t3.micro"
+
+// DefaultHetznerInstanceType is the default instance type for Hetzner.
+const DefaultHetznerInstanceType = "cx11"
+
+// DefaultAWSRate is the fallback hourly rate for unknown AWS instances.
+const DefaultAWSRate = 0.0104
+
+// DefaultHetznerRate is the fallback hourly rate for unknown Hetzner instances.
+const DefaultHetznerRate = 0.0050
+
+// GetAWSHourlyRate returns the hourly rate and currency for an AWS instance.
+// Falls back to default rate if instance type or region is not found.
+func GetAWSHourlyRate(instanceType, region string) (rate float64, currency string) {
+	if instances, ok := AWSPricing[instanceType]; ok {
+		if rate, ok := instances[region]; ok {
+			return rate, "USD"
+		}
+		// Region not found, use us-east-1 rate if available
+		if rate, ok := instances["us-east-1"]; ok {
+			return rate, "USD"
+		}
+	}
+	return DefaultAWSRate, "USD"
+}
+
+// GetHetznerHourlyRate returns the hourly rate and currency for a Hetzner server.
+// Falls back to default rate if server type is not found.
+func GetHetznerHourlyRate(serverType string) (rate float64, currency string) {
+	if rate, ok := HetznerPricing[serverType]; ok {
+		return rate, "USD"
+	}
+	return DefaultHetznerRate, "USD"
+}
+
+// GetHourlyRate returns the hourly rate and currency for a provider and instance type.
+// providerName should be "aws" or "hetzner".
+func GetHourlyRate(providerName, instanceType, region string) (rate float64, currency string) {
+	switch providerName {
+	case "aws":
+		return GetAWSHourlyRate(instanceType, region)
+	case "hetzner":
+		return GetHetznerHourlyRate(instanceType)
+	default:
+		return 0, "USD"
+	}
+}
+
+// ListAWSInstanceTypes returns a list of supported AWS instance types.
+func ListAWSInstanceTypes() []string {
+	types := make([]string, 0, len(AWSPricing))
+	for t := range AWSPricing {
+		types = append(types, t)
+	}
+	return types
+}
+
+// ListHetznerInstanceTypes returns a list of supported Hetzner server types.
+func ListHetznerInstanceTypes() []string {
+	types := make([]string, 0, len(HetznerPricing))
+	for t := range HetznerPricing {
+		types = append(types, t)
+	}
+	return types
+}

--- a/internal/cost/pricing_test.go
+++ b/internal/cost/pricing_test.go
@@ -1,0 +1,194 @@
+package cost
+
+import (
+	"testing"
+)
+
+func TestGetAWSHourlyRate(t *testing.T) {
+	tests := []struct {
+		instanceType string
+		region       string
+		expectedRate float64
+	}{
+		{"t3.micro", "us-east-1", 0.0104},
+		{"t3.micro", "eu-west-1", 0.0116},
+		{"t3.small", "us-east-1", 0.0208},
+		{"t3.nano", "us-west-2", 0.0052},
+		{"t2.micro", "us-east-1", 0.0116},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.instanceType+"_"+tc.region, func(t *testing.T) {
+			rate, currency := GetAWSHourlyRate(tc.instanceType, tc.region)
+			if rate != tc.expectedRate {
+				t.Errorf("expected rate %f, got %f", tc.expectedRate, rate)
+			}
+			if currency != "USD" {
+				t.Errorf("expected USD, got %s", currency)
+			}
+		})
+	}
+}
+
+func TestGetAWSHourlyRateFallback(t *testing.T) {
+	// Unknown instance type should fall back to default
+	rate, currency := GetAWSHourlyRate("unknown-type", "us-east-1")
+	if rate != DefaultAWSRate {
+		t.Errorf("expected default rate %f, got %f", DefaultAWSRate, rate)
+	}
+	if currency != "USD" {
+		t.Errorf("expected USD, got %s", currency)
+	}
+
+	// Unknown region should fall back to us-east-1 rate
+	rate, currency = GetAWSHourlyRate("t3.micro", "unknown-region")
+	if rate != 0.0104 {
+		t.Errorf("expected us-east-1 fallback rate 0.0104, got %f", rate)
+	}
+	if currency != "USD" {
+		t.Errorf("expected USD, got %s", currency)
+	}
+}
+
+func TestGetHetznerHourlyRate(t *testing.T) {
+	tests := []struct {
+		serverType   string
+		expectedRate float64
+	}{
+		{"cx11", 0.0050},
+		{"cx21", 0.0088},
+		{"cx31", 0.0159},
+		{"cpx11", 0.0066},
+		{"cax11", 0.0053},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.serverType, func(t *testing.T) {
+			rate, currency := GetHetznerHourlyRate(tc.serverType)
+			if rate != tc.expectedRate {
+				t.Errorf("expected rate %f, got %f", tc.expectedRate, rate)
+			}
+			if currency != "USD" {
+				t.Errorf("expected USD, got %s", currency)
+			}
+		})
+	}
+}
+
+func TestGetHetznerHourlyRateFallback(t *testing.T) {
+	// Unknown server type should fall back to default
+	rate, currency := GetHetznerHourlyRate("unknown-type")
+	if rate != DefaultHetznerRate {
+		t.Errorf("expected default rate %f, got %f", DefaultHetznerRate, rate)
+	}
+	if currency != "USD" {
+		t.Errorf("expected USD, got %s", currency)
+	}
+}
+
+func TestGetHourlyRate(t *testing.T) {
+	tests := []struct {
+		provider     string
+		instanceType string
+		region       string
+		expectedRate float64
+		expectedCurr string
+	}{
+		{"aws", "t3.micro", "us-east-1", 0.0104, "USD"},
+		{"aws", "t3.small", "eu-west-1", 0.0232, "USD"},
+		{"hetzner", "cx11", "", 0.0050, "USD"},
+		{"hetzner", "cpx11", "fsn1", 0.0066, "USD"},
+		{"unknown", "any", "any", 0, "USD"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.provider+"_"+tc.instanceType, func(t *testing.T) {
+			rate, currency := GetHourlyRate(tc.provider, tc.instanceType, tc.region)
+			if rate != tc.expectedRate {
+				t.Errorf("expected rate %f, got %f", tc.expectedRate, rate)
+			}
+			if currency != tc.expectedCurr {
+				t.Errorf("expected %s, got %s", tc.expectedCurr, currency)
+			}
+		})
+	}
+}
+
+func TestListAWSInstanceTypes(t *testing.T) {
+	types := ListAWSInstanceTypes()
+	if len(types) == 0 {
+		t.Error("expected non-empty list of AWS instance types")
+	}
+
+	// Verify known types are in the list
+	typeMap := make(map[string]bool)
+	for _, typ := range types {
+		typeMap[typ] = true
+	}
+
+	expected := []string{"t3.micro", "t3.small", "t3.nano"}
+	for _, exp := range expected {
+		if !typeMap[exp] {
+			t.Errorf("expected %s in list", exp)
+		}
+	}
+}
+
+func TestListHetznerInstanceTypes(t *testing.T) {
+	types := ListHetznerInstanceTypes()
+	if len(types) == 0 {
+		t.Error("expected non-empty list of Hetzner server types")
+	}
+
+	// Verify known types are in the list
+	typeMap := make(map[string]bool)
+	for _, typ := range types {
+		typeMap[typ] = true
+	}
+
+	expected := []string{"cx11", "cx21", "cpx11", "cax11"}
+	for _, exp := range expected {
+		if !typeMap[exp] {
+			t.Errorf("expected %s in list", exp)
+		}
+	}
+}
+
+func TestAWSPricingDataExists(t *testing.T) {
+	// Verify pricing data exists for default instance type
+	if _, ok := AWSPricing[DefaultAWSInstanceType]; !ok {
+		t.Errorf("pricing data missing for default AWS instance type %s", DefaultAWSInstanceType)
+	}
+
+	// Verify at least us-east-1 region exists for each instance type
+	for instanceType, regions := range AWSPricing {
+		if _, ok := regions["us-east-1"]; !ok {
+			t.Errorf("us-east-1 pricing missing for %s", instanceType)
+		}
+	}
+}
+
+func TestHetznerPricingDataExists(t *testing.T) {
+	// Verify pricing data exists for default server type
+	if _, ok := HetznerPricing[DefaultHetznerInstanceType]; !ok {
+		t.Errorf("pricing data missing for default Hetzner server type %s", DefaultHetznerInstanceType)
+	}
+}
+
+func TestPricingRatesArePositive(t *testing.T) {
+	// All AWS rates should be positive
+	for instanceType, regions := range AWSPricing {
+		for region, rate := range regions {
+			if rate <= 0 {
+				t.Errorf("AWS %s in %s has non-positive rate: %f", instanceType, region, rate)
+			}
+		}
+	}
+
+	// All Hetzner rates should be positive
+	for serverType, rate := range HetznerPricing {
+		if rate <= 0 {
+			t.Errorf("Hetzner %s has non-positive rate: %f", serverType, rate)
+		}
+	}
+}

--- a/internal/cost/tracker.go
+++ b/internal/cost/tracker.go
@@ -1,4 +1,131 @@
-// Package cost provides cost tracking
+// Package cost provides cost tracking for VPN sessions.
 package cost
 
-// TODO: Implementation will be added in future issues
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Tracker tracks the cost of a VPN session based on hourly rate and duration.
+type Tracker struct {
+	mu         sync.RWMutex
+	started    time.Time
+	hourlyRate float64
+	currency   string
+	isTracking bool
+}
+
+// NewTracker creates a new Tracker instance.
+func NewTracker() *Tracker {
+	return &Tracker{}
+}
+
+// Start begins tracking cost with the given hourly rate and currency.
+func (t *Tracker) Start(hourlyRate float64, currency string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.started = time.Now()
+	t.hourlyRate = hourlyRate
+	t.currency = currency
+	t.isTracking = true
+}
+
+// Stop stops tracking cost.
+func (t *Tracker) Stop() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.isTracking = false
+}
+
+// IsTracking returns true if the tracker is currently tracking a session.
+func (t *Tracker) IsTracking() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.isTracking
+}
+
+// CurrentCost returns the current accumulated cost and currency.
+// Returns (0, currency) if not tracking.
+func (t *Tracker) CurrentCost() (cost float64, currency string) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if !t.isTracking {
+		return 0, t.currency
+	}
+
+	duration := time.Since(t.started)
+	hours := duration.Hours()
+	return t.hourlyRate * hours, t.currency
+}
+
+// Duration returns the current session duration.
+// Returns 0 if not tracking.
+func (t *Tracker) Duration() time.Duration {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if !t.isTracking {
+		return 0
+	}
+	return time.Since(t.started)
+}
+
+// HourlyRate returns the configured hourly rate.
+func (t *Tracker) HourlyRate() float64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.hourlyRate
+}
+
+// Currency returns the configured currency.
+func (t *Tracker) Currency() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.currency
+}
+
+// FormatCost returns a formatted string of the current cost (e.g., "$0.0052").
+func (t *Tracker) FormatCost() string {
+	cost, currency := t.CurrentCost()
+	return FormatCostValue(cost, currency)
+}
+
+// FormatDuration returns a formatted string of the session duration (e.g., "00:30:15").
+func (t *Tracker) FormatDuration() string {
+	duration := t.Duration()
+	return FormatDurationValue(duration)
+}
+
+// FormatHourlyRate returns a formatted string of the hourly rate (e.g., "$0.0104/hr").
+func (t *Tracker) FormatHourlyRate() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return formatRateValue(t.hourlyRate, t.currency)
+}
+
+// FormatCostValue formats a cost value with the appropriate currency symbol.
+func FormatCostValue(cost float64, currency string) string {
+	symbol := "$"
+	if currency == "EUR" {
+		symbol = "€"
+	}
+	return fmt.Sprintf("%s%.4f", symbol, cost)
+}
+
+// FormatDurationValue formats a duration as HH:MM:SS.
+func FormatDurationValue(d time.Duration) string {
+	hours := int(d.Hours())
+	minutes := int(d.Minutes()) % 60
+	seconds := int(d.Seconds()) % 60
+	return fmt.Sprintf("%02d:%02d:%02d", hours, minutes, seconds)
+}
+
+// formatRateValue formats a rate with the appropriate currency symbol and /hr suffix.
+func formatRateValue(rate float64, currency string) string {
+	symbol := "$"
+	if currency == "EUR" {
+		symbol = "€"
+	}
+	return fmt.Sprintf("%s%.4f/hr", symbol, rate)
+}

--- a/internal/cost/tracker_test.go
+++ b/internal/cost/tracker_test.go
@@ -1,0 +1,229 @@
+package cost
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewTracker(t *testing.T) {
+	tracker := NewTracker()
+	if tracker == nil {
+		t.Fatal("NewTracker() returned nil")
+	}
+	if tracker.IsTracking() {
+		t.Error("new tracker should not be tracking")
+	}
+}
+
+func TestTrackerStartStop(t *testing.T) {
+	tracker := NewTracker()
+
+	tracker.Start(0.01, "USD")
+	if !tracker.IsTracking() {
+		t.Error("tracker should be tracking after Start()")
+	}
+	if tracker.HourlyRate() != 0.01 {
+		t.Errorf("expected hourly rate 0.01, got %f", tracker.HourlyRate())
+	}
+	if tracker.Currency() != "USD" {
+		t.Errorf("expected currency USD, got %s", tracker.Currency())
+	}
+
+	tracker.Stop()
+	if tracker.IsTracking() {
+		t.Error("tracker should not be tracking after Stop()")
+	}
+}
+
+func TestTrackerCurrentCost(t *testing.T) {
+	tracker := NewTracker()
+
+	// Before starting, cost should be 0
+	cost, _ := tracker.CurrentCost()
+	if cost != 0 {
+		t.Errorf("expected cost 0 before start, got %f", cost)
+	}
+
+	// Start tracking
+	tracker.Start(0.01, "USD") // $0.01/hour
+
+	// Wait a small amount of time
+	time.Sleep(100 * time.Millisecond)
+
+	cost, currency := tracker.CurrentCost()
+	if cost <= 0 {
+		t.Error("expected positive cost after tracking")
+	}
+	if currency != "USD" {
+		t.Errorf("expected USD, got %s", currency)
+	}
+
+	// Stop and verify cost is 0
+	tracker.Stop()
+	cost, _ = tracker.CurrentCost()
+	if cost != 0 {
+		t.Errorf("expected cost 0 after stop, got %f", cost)
+	}
+}
+
+func TestTrackerDuration(t *testing.T) {
+	tracker := NewTracker()
+
+	// Before starting, duration should be 0
+	if tracker.Duration() != 0 {
+		t.Error("expected 0 duration before start")
+	}
+
+	tracker.Start(0.01, "USD")
+	time.Sleep(50 * time.Millisecond)
+
+	duration := tracker.Duration()
+	if duration < 50*time.Millisecond {
+		t.Errorf("expected duration >= 50ms, got %v", duration)
+	}
+
+	tracker.Stop()
+	if tracker.Duration() != 0 {
+		t.Error("expected 0 duration after stop")
+	}
+}
+
+func TestTrackerFormatCost(t *testing.T) {
+	tracker := NewTracker()
+	tracker.Start(36.0, "USD") // $36/hour = $0.01/second
+
+	time.Sleep(100 * time.Millisecond)
+
+	formatted := tracker.FormatCost()
+	if formatted == "" {
+		t.Error("FormatCost() returned empty string")
+	}
+	// Should start with $ for USD
+	if formatted[0] != '$' {
+		t.Errorf("expected USD format to start with $, got %s", formatted)
+	}
+
+	// Test EUR formatting
+	tracker.Stop()
+	tracker.Start(36.0, "EUR")
+	time.Sleep(50 * time.Millisecond)
+	formatted = tracker.FormatCost()
+	if !strings.HasPrefix(formatted, "€") {
+		t.Errorf("expected EUR format to start with €, got %s", formatted)
+	}
+}
+
+func TestTrackerFormatDuration(t *testing.T) {
+	tracker := NewTracker()
+	tracker.Start(0.01, "USD")
+	time.Sleep(50 * time.Millisecond)
+
+	formatted := tracker.FormatDuration()
+	// Should be in HH:MM:SS format
+	if len(formatted) != 8 || formatted[2] != ':' || formatted[5] != ':' {
+		t.Errorf("expected HH:MM:SS format, got %s", formatted)
+	}
+}
+
+func TestTrackerFormatHourlyRate(t *testing.T) {
+	tracker := NewTracker()
+	tracker.Start(0.0104, "USD")
+
+	formatted := tracker.FormatHourlyRate()
+	expected := "$0.0104/hr"
+	if formatted != expected {
+		t.Errorf("expected %s, got %s", expected, formatted)
+	}
+
+	tracker.Stop()
+	tracker.Start(0.005, "EUR")
+	formatted = tracker.FormatHourlyRate()
+	expected = "€0.0050/hr"
+	if formatted != expected {
+		t.Errorf("expected %s, got %s", expected, formatted)
+	}
+}
+
+func TestFormatCostValue(t *testing.T) {
+	tests := []struct {
+		cost     float64
+		currency string
+		expected string
+	}{
+		{0.0052, "USD", "$0.0052"},
+		{1.2345, "USD", "$1.2345"},
+		{0.0050, "EUR", "€0.0050"},
+		{10.0000, "EUR", "€10.0000"},
+	}
+
+	for _, tc := range tests {
+		result := FormatCostValue(tc.cost, tc.currency)
+		if result != tc.expected {
+			t.Errorf("FormatCostValue(%f, %s) = %s, expected %s",
+				tc.cost, tc.currency, result, tc.expected)
+		}
+	}
+}
+
+func TestFormatDurationValue(t *testing.T) {
+	tests := []struct {
+		duration time.Duration
+		expected string
+	}{
+		{0, "00:00:00"},
+		{30 * time.Second, "00:00:30"},
+		{5 * time.Minute, "00:05:00"},
+		{1 * time.Hour, "01:00:00"},
+		{1*time.Hour + 30*time.Minute + 15*time.Second, "01:30:15"},
+		{25 * time.Hour, "25:00:00"},
+	}
+
+	for _, tc := range tests {
+		result := FormatDurationValue(tc.duration)
+		if result != tc.expected {
+			t.Errorf("FormatDurationValue(%v) = %s, expected %s",
+				tc.duration, result, tc.expected)
+		}
+	}
+}
+
+func TestTrackerConcurrency(t *testing.T) {
+	tracker := NewTracker()
+
+	// Start multiple goroutines accessing the tracker
+	done := make(chan bool)
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			tracker.Start(0.01, "USD")
+		}
+		done <- true
+	}()
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			tracker.Stop()
+		}
+		done <- true
+	}()
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			tracker.CurrentCost()
+		}
+		done <- true
+	}()
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			tracker.Duration()
+		}
+		done <- true
+	}()
+
+	// Wait for all goroutines
+	for i := 0; i < 4; i++ {
+		<-done
+	}
+}


### PR DESCRIPTION
## Summary
- Add cost tracking module (`internal/cost/tracker.go`) with thread-safe Start/Stop/CurrentCost/Duration methods
- Add embedded pricing data for AWS EC2 instances (7 types across 10 regions) and Hetzner servers (14 types)
- Add format helpers for cost display ($0.0052), duration (HH:MM:SS), and hourly rate ($0.0104/hr)

Closes #29

## Test plan
- [x] Run `go test ./internal/cost/...` - all tests pass
- [x] Run `golangci-lint run ./internal/cost/...` - no issues
- [ ] Manual verification: integrate with UI ticker to verify real-time cost updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)