### PR TITLE
feat: Hide Windows console on startup with toggle menu option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,11 @@ jobs:
       - name: Build
         run: |
           mkdir -p dist
-          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o dist/${{ matrix.artifact }} ./cmd/my-own-vpn
+          LDFLAGS=""
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            LDFLAGS="-H windowsgui"
+          fi
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="$LDFLAGS" -o dist/${{ matrix.artifact }} ./cmd/my-own-vpn
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,13 @@ jobs:
       - name: Build binary
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
+        shell: bash
         run: |
-          go build -ldflags="-s -w -X main.Version=${{ steps.version.outputs.VERSION }}" -o ${{ matrix.artifact }} ./cmd/my-own-vpn
+          LDFLAGS="-s -w -X main.Version=${{ steps.version.outputs.VERSION }}"
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            LDFLAGS="$LDFLAGS -H windowsgui"
+          fi
+          go build -ldflags="$LDFLAGS" -o ${{ matrix.artifact }} ./cmd/my-own-vpn
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test lint fmt clean tools check security tools-security
+.PHONY: all build build-windows test lint fmt clean tools check security tools-security
 
 # Binary name
 BINARY_NAME=my-own-vpn
@@ -6,11 +6,16 @@ VERSION?=dev
 
 # Build flags
 LDFLAGS=-s -w -X main.Version=$(VERSION)
+# Windows-specific LDFLAGS to hide console window
+LDFLAGS_WINDOWS=$(LDFLAGS) -H windowsgui
 
 all: lint test build
 
 build:
 	go build -ldflags="$(LDFLAGS)" -o $(BINARY_NAME) ./cmd/my-own-vpn
+
+build-windows:
+	GOOS=windows GOARCH=amd64 go build -ldflags="$(LDFLAGS_WINDOWS)" -o $(BINARY_NAME).exe ./cmd/my-own-vpn
 
 test:
 	go test -v -race ./...

--- a/internal/ui/console.go
+++ b/internal/ui/console.go
@@ -1,0 +1,31 @@
+//go:build cgo
+
+package ui
+
+// ConsoleController provides methods to show/hide the console window.
+// This is primarily useful on Windows where GUI applications don't have
+// a console by default, but users may want to see logs for debugging.
+type ConsoleController interface {
+	// ShowConsole shows the console window if hidden.
+	// Returns true if the console is now visible.
+	ShowConsole() bool
+
+	// HideConsole hides the console window if visible.
+	// Returns true if the console is now hidden.
+	HideConsole() bool
+
+	// IsConsoleVisible returns whether the console is currently visible.
+	IsConsoleVisible() bool
+
+	// ToggleConsole toggles the console visibility.
+	// Returns true if the console is now visible.
+	ToggleConsole() bool
+}
+
+// Console is the global console controller instance.
+// It is initialized with platform-specific implementation.
+var Console ConsoleController
+
+func init() {
+	Console = newConsoleController()
+}

--- a/internal/ui/console_other.go
+++ b/internal/ui/console_other.go
@@ -30,13 +30,3 @@ func (c *noopConsoleController) IsConsoleVisible() bool {
 func (c *noopConsoleController) ToggleConsole() bool {
 	return false
 }
-
-// IsWindows returns false on non-Windows platforms.
-func IsWindows() bool {
-	return false
-}
-
-// ConsoleSupportedMsg returns a message indicating console toggle is not supported.
-func ConsoleSupportedMsg() string {
-	return "Console toggle is only available on Windows"
-}

--- a/internal/ui/console_other.go
+++ b/internal/ui/console_other.go
@@ -1,0 +1,42 @@
+//go:build !windows && cgo
+
+package ui
+
+// noopConsoleController is a no-op implementation for non-Windows platforms.
+// On macOS and Linux, console management is not needed as the app runs
+// from a terminal or has proper logging facilities.
+type noopConsoleController struct{}
+
+func newConsoleController() ConsoleController {
+	return &noopConsoleController{}
+}
+
+// ShowConsole is a no-op on non-Windows platforms.
+func (c *noopConsoleController) ShowConsole() bool {
+	return false
+}
+
+// HideConsole is a no-op on non-Windows platforms.
+func (c *noopConsoleController) HideConsole() bool {
+	return false
+}
+
+// IsConsoleVisible always returns false on non-Windows platforms.
+func (c *noopConsoleController) IsConsoleVisible() bool {
+	return false
+}
+
+// ToggleConsole is a no-op on non-Windows platforms.
+func (c *noopConsoleController) ToggleConsole() bool {
+	return false
+}
+
+// IsWindows returns false on non-Windows platforms.
+func IsWindows() bool {
+	return false
+}
+
+// ConsoleSupportedMsg returns a message indicating console toggle is not supported.
+func ConsoleSupportedMsg() string {
+	return "Console toggle is only available on Windows"
+}

--- a/internal/ui/console_test.go
+++ b/internal/ui/console_test.go
@@ -13,26 +13,12 @@ func TestConsoleControllerExists(t *testing.T) {
 	}
 }
 
-func TestIsWindows(t *testing.T) {
+func TestIsWindowsConsistency(t *testing.T) {
 	isWin := IsWindows()
 	actuallyWindows := runtime.GOOS == "windows"
 
 	if isWin != actuallyWindows {
 		t.Errorf("IsWindows() = %v, but runtime.GOOS = %v", isWin, runtime.GOOS)
-	}
-}
-
-func TestConsoleSupportedMsg(t *testing.T) {
-	msg := ConsoleSupportedMsg()
-
-	if runtime.GOOS == "windows" {
-		if msg != "" {
-			t.Errorf("expected empty message on Windows, got %q", msg)
-		}
-	} else {
-		if msg == "" {
-			t.Error("expected non-empty message on non-Windows platforms")
-		}
 	}
 }
 
@@ -48,8 +34,7 @@ func TestConsoleOperations(t *testing.T) {
 			t.Error("ShowConsole should return false on non-Windows")
 		}
 		if Console.HideConsole() {
-			// HideConsole returns true when already hidden on Windows implementation
-			// but for noop, it returns false
+			t.Error("HideConsole should return false on non-Windows")
 		}
 		if Console.ToggleConsole() {
 			t.Error("ToggleConsole should return false on non-Windows")

--- a/internal/ui/console_test.go
+++ b/internal/ui/console_test.go
@@ -1,0 +1,76 @@
+//go:build cgo
+
+package ui
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestConsoleControllerExists(t *testing.T) {
+	if Console == nil {
+		t.Fatal("Console controller is nil")
+	}
+}
+
+func TestIsWindows(t *testing.T) {
+	isWin := IsWindows()
+	actuallyWindows := runtime.GOOS == "windows"
+
+	if isWin != actuallyWindows {
+		t.Errorf("IsWindows() = %v, but runtime.GOOS = %v", isWin, runtime.GOOS)
+	}
+}
+
+func TestConsoleSupportedMsg(t *testing.T) {
+	msg := ConsoleSupportedMsg()
+
+	if runtime.GOOS == "windows" {
+		if msg != "" {
+			t.Errorf("expected empty message on Windows, got %q", msg)
+		}
+	} else {
+		if msg == "" {
+			t.Error("expected non-empty message on non-Windows platforms")
+		}
+	}
+}
+
+func TestConsoleOperations(t *testing.T) {
+	// Initial state should be not visible
+	if Console.IsConsoleVisible() {
+		t.Error("expected console to not be visible initially")
+	}
+
+	if runtime.GOOS != "windows" {
+		// On non-Windows platforms, all operations should return false
+		if Console.ShowConsole() {
+			t.Error("ShowConsole should return false on non-Windows")
+		}
+		if Console.HideConsole() {
+			// HideConsole returns true when already hidden on Windows implementation
+			// but for noop, it returns false
+		}
+		if Console.ToggleConsole() {
+			t.Error("ToggleConsole should return false on non-Windows")
+		}
+		if Console.IsConsoleVisible() {
+			t.Error("IsConsoleVisible should return false on non-Windows")
+		}
+	}
+}
+
+func TestToggleConsole(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		// On non-Windows, toggle should always return false
+		result := Console.ToggleConsole()
+		if result {
+			t.Error("ToggleConsole should return false on non-Windows")
+		}
+		if Console.IsConsoleVisible() {
+			t.Error("console should never be visible on non-Windows")
+		}
+	}
+	// Note: Windows-specific tests would require actual Windows environment
+	// and might interfere with the test runner's console
+}

--- a/internal/ui/console_windows.go
+++ b/internal/ui/console_windows.go
@@ -121,13 +121,3 @@ func (c *windowsConsoleController) redirectStdHandles() error {
 
 	return nil
 }
-
-// IsWindows returns true on Windows.
-func IsWindows() bool {
-	return true
-}
-
-// ConsoleSupportedMsg returns empty string on Windows since console is supported.
-func ConsoleSupportedMsg() string {
-	return ""
-}

--- a/internal/ui/console_windows.go
+++ b/internal/ui/console_windows.go
@@ -1,0 +1,133 @@
+//go:build windows && cgo
+
+package ui
+
+import (
+	"os"
+	"sync"
+	"syscall"
+)
+
+var (
+	kernel32         = syscall.NewLazyDLL("kernel32.dll")
+	procAllocConsole = kernel32.NewProc("AllocConsole")
+	procFreeConsole  = kernel32.NewProc("FreeConsole")
+	procGetConsole   = kernel32.NewProc("GetConsoleWindow")
+	procSetStdHandle = kernel32.NewProc("SetStdHandle")
+)
+
+const (
+	stdOutputHandle = ^uintptr(0) - 10 + 1 // STD_OUTPUT_HANDLE = -11
+	stdErrorHandle  = ^uintptr(0) - 11 + 1 // STD_ERROR_HANDLE = -12
+)
+
+// windowsConsoleController implements ConsoleController for Windows.
+type windowsConsoleController struct {
+	mu      sync.Mutex
+	visible bool
+}
+
+func newConsoleController() ConsoleController {
+	return &windowsConsoleController{
+		visible: false,
+	}
+}
+
+// ShowConsole allocates a new console and redirects stdout/stderr to it.
+func (c *windowsConsoleController) ShowConsole() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.visible {
+		return true
+	}
+
+	// Allocate a new console
+	ret, _, _ := procAllocConsole.Call()
+	if ret == 0 {
+		// AllocConsole failed, but we may already have a console
+		// Check if we have a console window
+		hwnd, _, _ := procGetConsole.Call()
+		if hwnd == 0 {
+			return false
+		}
+	}
+
+	// Redirect stdout and stderr to the console
+	if err := c.redirectStdHandles(); err != nil {
+		return false
+	}
+
+	c.visible = true
+	return true
+}
+
+// HideConsole frees the console window.
+func (c *windowsConsoleController) HideConsole() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if !c.visible {
+		return true
+	}
+
+	// Free the console
+	ret, _, _ := procFreeConsole.Call()
+	if ret == 0 {
+		return false
+	}
+
+	c.visible = false
+	return true
+}
+
+// IsConsoleVisible returns whether the console is currently visible.
+func (c *windowsConsoleController) IsConsoleVisible() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.visible
+}
+
+// ToggleConsole toggles console visibility.
+func (c *windowsConsoleController) ToggleConsole() bool {
+	c.mu.Lock()
+	visible := c.visible
+	c.mu.Unlock()
+
+	if visible {
+		c.HideConsole()
+		return false
+	}
+	c.ShowConsole()
+	return true
+}
+
+// redirectStdHandles redirects os.Stdout and os.Stderr to the console.
+func (c *windowsConsoleController) redirectStdHandles() error {
+	// Open CONOUT$ for writing
+	conout, err := os.OpenFile("CONOUT$", os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+
+	// Set the standard handles
+	handle := conout.Fd()
+	procSetStdHandle.Call(stdOutputHandle, handle)
+	procSetStdHandle.Call(stdErrorHandle, handle)
+
+	// Replace os.Stdout and os.Stderr
+	os.Stdout = conout
+	os.Stderr = conout
+
+	return nil
+}
+
+// IsWindows returns true on Windows.
+func IsWindows() bool {
+	return true
+}
+
+// ConsoleSupportedMsg returns empty string on Windows since console is supported.
+func ConsoleSupportedMsg() string {
+	return ""
+}

--- a/internal/ui/systray.go
+++ b/internal/ui/systray.go
@@ -34,6 +34,7 @@ type TrayApp struct {
 	mDisconnect *fyne.MenuItem
 	mSettings   *fyne.MenuItem
 	mCost       *fyne.MenuItem
+	mConsole    *fyne.MenuItem
 
 	// Callbacks
 	onConnect    func()
@@ -115,6 +116,14 @@ func (t *TrayApp) Setup() {
 		t.mCost = fyne.NewMenuItem("Session Cost: $0.00", nil)
 		t.mCost.Disabled = true
 
+		t.mConsole = fyne.NewMenuItem("Show Console", func() {
+			t.toggleConsole()
+		})
+		// Console toggle is only available on Windows
+		if !IsWindows() {
+			t.mConsole.Disabled = true
+		}
+
 		quitItem := fyne.NewMenuItem("Quit", func() {
 			t.mu.RLock()
 			cb := t.onQuit
@@ -134,6 +143,7 @@ func (t *TrayApp) Setup() {
 			t.mSettings,
 			fyne.NewMenuItemSeparator(),
 			t.mCost,
+			t.mConsole,
 			fyne.NewMenuItemSeparator(),
 			quitItem,
 		)
@@ -282,5 +292,21 @@ func (t *TrayApp) Quit() {
 
 	if app != nil {
 		app.Quit()
+	}
+}
+
+// toggleConsole toggles the console visibility and updates the menu label.
+func (t *TrayApp) toggleConsole() {
+	visible := Console.ToggleConsole()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.mConsole != nil {
+		if visible {
+			t.mConsole.Label = "Hide Console"
+		} else {
+			t.mConsole.Label = "Show Console"
+		}
 	}
 }

--- a/internal/ui/systray_linux.go
+++ b/internal/ui/systray_linux.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package ui
+
+// Platform-specific initialization for Linux
+// The getlantern/systray library handles most Linux specifics automatically.
+// This file can be extended for Linux-specific functionality.
+
+func init() {
+	// Linux-specific initialization can be added here
+}
+
+// IsMacOS returns false on Linux builds
+func IsMacOS() bool {
+	return false
+}
+
+// IsWindows returns false on Linux builds
+func IsWindows() bool {
+	return false
+}


### PR DESCRIPTION
## Summary

- Hide the console window that appears when the app starts on Windows by using `-H windowsgui` linker flag
- Add a "Show Console" menu option in the system tray to toggle console visibility for debugging purposes
- Implement `ConsoleController` interface with Windows-specific implementation using kernel32.dll APIs

## Changes

### New Files
- `internal/ui/console.go` - Interface definition for `ConsoleController`
- `internal/ui/console_windows.go` - Windows implementation using `AllocConsole`/`FreeConsole` APIs
- `internal/ui/console_other.go` - No-op stub for non-Windows platforms
- `internal/ui/console_test.go` - Tests for the console controller

### Modified Files
- `internal/ui/systray.go` - Added console toggle menu item
- `Makefile` - Added `build-windows` target with `-H windowsgui`
- `.github/workflows/ci.yml` - Windows builds now use `-H windowsgui`
- `.github/workflows/release.yml` - Windows releases now use `-H windowsgui`

## Test plan

- [ ] Build locally for Windows: `make build-windows`
- [ ] Run on Windows - verify no console appears on startup
- [ ] Click "Show Console" in tray menu - console appears
- [ ] Click "Hide Console" - console disappears
- [ ] Verify menu item is disabled on macOS
- [ ] Run tests: `go test ./internal/ui/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)