### PR TITLE
fix: Resolve Settings dialog freeze and menu state not updating

### DIFF
--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -93,26 +93,26 @@ func (s *SettingsWindow) SetOnStarted(callback func(fyne.App)) {
 // This method is safe to call from any goroutine - it schedules UI operations
 // on the main Fyne thread to avoid thread safety issues.
 func (s *SettingsWindow) Show() {
-	// Get fyneApp reference under lock
-	s.mu.Lock()
-	if s.fyneApp == nil {
-		s.fyneApp = app.New()
-	}
-	alreadyCreated := s.window != nil
-	s.mu.Unlock()
-
-	// Schedule all UI operations on the main Fyne thread
-	fyne.DoAndWait(func() {
+	// Schedule all UI operations on the main Fyne thread using non-blocking Do
+	// to avoid potential deadlocks with system tray menu callbacks on Windows
+	fyne.Do(func() {
 		s.mu.Lock()
 		defer s.mu.Unlock()
 
-		// Double-check window creation in case another goroutine created it
-		if !alreadyCreated && s.window == nil {
+		// Ensure we have a Fyne app
+		if s.fyneApp == nil {
+			// This shouldn't happen if RunFyneLoop was called, but handle it gracefully
+			return
+		}
+
+		// Create window if needed
+		if s.window == nil {
 			s.createWindow()
 		}
 
 		s.loadConfigToForm()
 		s.window.Show()
+		s.window.RequestFocus()
 		s.visible = true
 	})
 }
@@ -120,20 +120,14 @@ func (s *SettingsWindow) Show() {
 // Hide hides the settings window.
 // This method is safe to call from any goroutine.
 func (s *SettingsWindow) Hide() {
-	s.mu.Lock()
-	window := s.window
-	s.mu.Unlock()
-
-	if window != nil {
-		fyne.DoAndWait(func() {
-			s.mu.Lock()
-			defer s.mu.Unlock()
-			if s.window != nil {
-				s.window.Hide()
-				s.visible = false
-			}
-		})
-	}
+	fyne.Do(func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if s.window != nil {
+			s.window.Hide()
+			s.visible = false
+		}
+	})
 }
 
 // SetOnSave sets the callback function called when settings are saved

--- a/internal/ui/systray.go
+++ b/internal/ui/systray.go
@@ -28,6 +28,9 @@ type TrayApp struct {
 	state   ConnectionState
 	cost    string
 
+	// Menu reference for refreshing
+	menu *fyne.Menu
+
 	// Menu items
 	mStatus     *fyne.MenuItem
 	mConnect    *fyne.MenuItem
@@ -135,7 +138,7 @@ func (t *TrayApp) Setup() {
 		})
 
 		// Build the menu
-		menu := fyne.NewMenu("My Own VPN",
+		t.menu = fyne.NewMenu("My Own VPN",
 			t.mStatus,
 			fyne.NewMenuItemSeparator(),
 			t.mConnect,
@@ -152,7 +155,15 @@ func (t *TrayApp) Setup() {
 		t.mDisconnect.Disabled = true
 		t.mCost.Disabled = true
 
-		desk.SetSystemTrayMenu(menu)
+		desk.SetSystemTrayMenu(t.menu)
+	}
+}
+
+// refreshMenu refreshes the system tray menu to reflect updated item states.
+// Must be called with lock held.
+func (t *TrayApp) refreshMenu() {
+	if t.menu != nil {
+		t.menu.Refresh()
 	}
 }
 
@@ -191,6 +202,7 @@ func (t *TrayApp) UpdateStatus(status string, connected bool) {
 	}
 
 	t.mStatus.Label = "Status: " + status
+	t.refreshMenu()
 }
 
 // SetConnecting updates the UI for connecting state
@@ -215,6 +227,7 @@ func (t *TrayApp) SetConnecting() {
 	t.mStatus.Label = "Status: Connecting..."
 	t.mConnect.Disabled = true
 	t.mDisconnect.Disabled = true
+	t.refreshMenu()
 }
 
 // SetDisconnecting updates the UI for disconnecting state
@@ -239,6 +252,7 @@ func (t *TrayApp) SetDisconnecting() {
 	t.mStatus.Label = "Status: Disconnecting..."
 	t.mConnect.Disabled = true
 	t.mDisconnect.Disabled = true
+	t.refreshMenu()
 }
 
 // UpdateCost updates the displayed session cost
@@ -249,6 +263,7 @@ func (t *TrayApp) UpdateCost(cost string) {
 	t.cost = cost
 	if t.mCost != nil {
 		t.mCost.Label = "Session Cost: " + cost
+		t.refreshMenu()
 	}
 }
 
@@ -275,6 +290,7 @@ func (t *TrayApp) SetError(message string) {
 	t.mConnect.Disabled = false
 	t.mDisconnect.Disabled = true
 	t.mCost.Disabled = true
+	t.refreshMenu()
 }
 
 // GetState returns the current connection state
@@ -308,5 +324,6 @@ func (t *TrayApp) toggleConsole() {
 		} else {
 			t.mConsole.Label = "Show Console"
 		}
+		t.refreshMenu()
 	}
 }


### PR DESCRIPTION
## Summary
- Fix Settings dialog not appearing and freezing the menu on Windows by replacing `fyne.DoAndWait` with non-blocking `fyne.Do`
- Fix menu items (Connect/Disconnect) not reflecting correct enabled/disabled state by adding `menu.Refresh()` calls after state updates

## Changes
1. **Settings dialog fix**: The `fyne.DoAndWait` call in `Show()` and `Hide()` methods could cause deadlocks when triggered from system tray menu callbacks on Windows. Switched to `fyne.Do` (non-blocking) to avoid this issue.

2. **Menu refresh fix**: In Fyne, changing `menuItem.Disabled` doesn't automatically refresh the system tray menu. Added a `refreshMenu()` helper that calls `menu.Refresh()` after any state update.

## Test plan
- [ ] On Windows: Click Settings - dialog should appear without freezing the menu
- [ ] On Windows: Click Connect - Disconnect should become enabled, Connect disabled
- [ ] On Windows: Click Disconnect - Connect should become enabled, Disconnect disabled
- [ ] On macOS: Verify Settings and Connect/Disconnect work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)