### PR TITLE
feat: Implement real connection flow in Controller (#79)

### DIFF
--- a/cmd/my-own-vpn/main.go
+++ b/cmd/my-own-vpn/main.go
@@ -3,11 +3,17 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"fyne.io/fyne/v2"
 	"github.com/gonfva/my-own-vpn/internal/app"
 	"github.com/gonfva/my-own-vpn/internal/config"
+	"github.com/gonfva/my-own-vpn/internal/credentials"
+	"github.com/gonfva/my-own-vpn/internal/provider"
+	"github.com/gonfva/my-own-vpn/internal/provider/aws"
+	"github.com/gonfva/my-own-vpn/internal/provider/hetzner"
 	"github.com/gonfva/my-own-vpn/internal/ui"
+	"github.com/gonfva/my-own-vpn/internal/wireguard"
 )
 
 // Version is set during build
@@ -18,6 +24,7 @@ var (
 	settingsWindow *ui.SettingsWindow
 	controller     *app.Controller
 	appConfig      *config.Config
+	credsMgr       credentials.Manager
 )
 
 func main() {
@@ -31,8 +38,27 @@ func main() {
 		appConfig = config.DefaultConfig()
 	}
 
-	// Create the controller
-	controller = app.NewController()
+	// Create credentials manager
+	credsMgr, err = credentials.NewManager()
+	if err != nil {
+		fmt.Printf("Failed to create credentials manager: %v\n", err)
+		return
+	}
+
+	// Create WireGuard client
+	wgClient, err := wireguard.NewClient()
+	if err != nil {
+		fmt.Printf("Failed to create WireGuard client: %v\n", err)
+		return
+	}
+
+	// Create the controller with dependencies
+	controller = app.NewController(app.ControllerDeps{
+		CredentialsManager: credsMgr,
+		WireGuardClient:    wgClient,
+		ProviderFactory:    createProvider,
+	})
+	controller.SetConfig(appConfig)
 	controller.SetOnStateChange(onControllerStateChange)
 	controller.SetOnError(onControllerError)
 
@@ -103,10 +129,67 @@ func onSettingsSaved(settingsConfig ui.SettingsConfig) {
 		return
 	}
 
-	// TODO: Store credentials in credential manager
-	// TODO: Update controller/provider with new config
+	// Store credentials in credential manager
+	ctx := context.Background()
+	providerType := strings.ToLower(settingsConfig.Provider)
+	switch providerType {
+	case "aws":
+		if settingsConfig.AWSAccessKeyID != "" || settingsConfig.AWSSecretAccessKey != "" {
+			err := credsMgr.SaveAWS(ctx, credentials.AWSCredentials{
+				AccessKeyID:     settingsConfig.AWSAccessKeyID,
+				SecretAccessKey: settingsConfig.AWSSecretAccessKey,
+			})
+			if err != nil {
+				fmt.Printf("Failed to save AWS credentials: %v\n", err)
+				tray.SetError(fmt.Sprintf("Failed to save credentials: %v", err))
+				return
+			}
+		}
+	case "hetzner":
+		if settingsConfig.HetznerAPIToken != "" {
+			err := credsMgr.SaveHetzner(ctx, credentials.HetznerCredentials{
+				APIToken: settingsConfig.HetznerAPIToken,
+			})
+			if err != nil {
+				fmt.Printf("Failed to save Hetzner credentials: %v\n", err)
+				tray.SetError(fmt.Sprintf("Failed to save credentials: %v", err))
+				return
+			}
+		}
+	}
+
+	// Update controller config
+	controller.SetConfig(appConfig)
 
 	fmt.Println("Configuration saved successfully")
+}
+
+// createProvider creates a cloud provider based on the provider type and region.
+// It loads the appropriate credentials from the credential manager.
+func createProvider(ctx context.Context, providerType, region string) (provider.Provider, error) {
+	providerType = strings.ToLower(providerType)
+	switch providerType {
+	case "aws":
+		creds, err := credsMgr.LoadAWS(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load AWS credentials: %w", err)
+		}
+		if creds == nil || creds.IsEmpty() {
+			return nil, fmt.Errorf("AWS credentials not configured")
+		}
+		return aws.New(ctx, creds.AccessKeyID, creds.SecretAccessKey, region)
+	case "hetzner":
+		creds, err := credsMgr.LoadHetzner(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load Hetzner credentials: %w", err)
+		}
+		if creds == nil || creds.IsEmpty() {
+			return nil, fmt.Errorf("Hetzner credentials not configured")
+		}
+		return hetzner.New(creds.APIToken)
+	default:
+		return nil, fmt.Errorf("unknown provider type: %s", providerType)
+	}
 }
 
 func onQuit() {

--- a/internal/app/controller.go
+++ b/internal/app/controller.go
@@ -3,9 +3,25 @@ package app
 import (
 	"context"
 	"fmt"
+	"log"
 	"sync"
 	"time"
+
+	"github.com/gonfva/my-own-vpn/internal/config"
+	"github.com/gonfva/my-own-vpn/internal/credentials"
+	"github.com/gonfva/my-own-vpn/internal/provider"
+	"github.com/gonfva/my-own-vpn/internal/wireguard"
 )
+
+// ProviderFactory creates a provider instance for the given type and region
+type ProviderFactory func(ctx context.Context, providerType, region string) (provider.Provider, error)
+
+// ControllerDeps contains dependencies for the Controller
+type ControllerDeps struct {
+	CredentialsManager credentials.Manager
+	WireGuardClient    wireguard.Client
+	ProviderFactory    ProviderFactory
+}
 
 // Controller manages the VPN lifecycle state machine
 type Controller struct {
@@ -22,6 +38,19 @@ type Controller struct {
 
 	// Cancellation support
 	cancelFunc context.CancelFunc // For aborting current operation
+
+	// Dependencies (injected)
+	credsMgr        credentials.Manager
+	wgClient        wireguard.Client
+	providerFactory ProviderFactory
+
+	// Configuration
+	config *config.Config
+
+	// Active session state (populated during connect)
+	activeProvider provider.Provider
+	serverInfo     *provider.ServerInfo
+	clientKeyPair  *wireguard.KeyPair
 }
 
 // validTransitions defines allowed state transitions
@@ -52,11 +81,21 @@ var validTransitions = map[State]map[State]bool{
 	},
 }
 
-// NewController creates a new Controller instance
-func NewController() *Controller {
+// NewController creates a new Controller instance with the given dependencies
+func NewController(deps ControllerDeps) *Controller {
 	return &Controller{
-		state: StateDisconnected,
+		state:           StateDisconnected,
+		credsMgr:        deps.CredentialsManager,
+		wgClient:        deps.WireGuardClient,
+		providerFactory: deps.ProviderFactory,
 	}
+}
+
+// SetConfig sets the configuration for the controller
+func (c *Controller) SetConfig(cfg *config.Config) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.config = cfg
 }
 
 // State returns the current state (thread-safe)
@@ -201,33 +240,109 @@ func (c *Controller) setState(newState State, message string) error {
 	return nil
 }
 
-// doConnect performs the connection process (stub implementation)
+// doConnect performs the connection process
 func (c *Controller) doConnect(ctx context.Context) {
-	// STUB: Simulate provisioning
-	select {
-	case <-ctx.Done():
-		c.handleError(ctx.Err(), "Operation cancelled during provisioning")
+	// Step 1: Validate configuration
+	c.mu.RLock()
+	cfg := c.config
+	c.mu.RUnlock()
+
+	if cfg == nil {
+		c.handleError(ctx, fmt.Errorf("no configuration set"), "Configuration required")
 		return
-	case <-time.After(2 * time.Second):
-		// Continue
+	}
+
+	if err := config.Validate(cfg); err != nil {
+		c.handleError(ctx, err, fmt.Sprintf("Invalid configuration: %v", err))
+		return
+	}
+
+	// Check for cancellation
+	if ctx.Err() != nil {
+		c.handleError(ctx, ctx.Err(), "Operation cancelled")
+		return
+	}
+
+	// Step 2: Create provider via factory function
+	if c.providerFactory == nil {
+		c.handleError(ctx, fmt.Errorf("no provider factory configured"), "Provider factory required")
+		return
+	}
+
+	prov, err := c.providerFactory(ctx, cfg.Provider, cfg.Region)
+	if err != nil {
+		c.handleError(ctx, err, fmt.Sprintf("Failed to create provider: %v", err))
+		return
 	}
 
 	c.mu.Lock()
-	if err := c.setState(StateConnecting, "Establishing connection..."); err != nil {
+	c.activeProvider = prov
+	c.mu.Unlock()
+
+	// Step 3: Validate credentials
+	if err := prov.ValidateCredentials(ctx); err != nil {
+		c.handleError(ctx, err, fmt.Sprintf("Invalid credentials: %v", err))
+		return
+	}
+
+	// Check for cancellation
+	if ctx.Err() != nil {
+		c.handleError(ctx, ctx.Err(), "Operation cancelled")
+		return
+	}
+
+	// Step 4: Generate WireGuard key pair
+	keyPair, err := wireguard.GenerateKeyPair()
+	if err != nil {
+		c.handleError(ctx, err, fmt.Sprintf("Failed to generate key pair: %v", err))
+		return
+	}
+
+	c.mu.Lock()
+	c.clientKeyPair = keyPair
+	c.mu.Unlock()
+
+	// Step 5: Provision infrastructure (already in Provisioning state)
+	serverInfo, err := prov.Provision(ctx, provider.ProvisionConfig{
+		Region:       cfg.Region,
+		InstanceType: cfg.InstanceType,
+	})
+	if err != nil {
+		c.handleError(ctx, err, fmt.Sprintf("Failed to provision infrastructure: %v", err))
+		return
+	}
+
+	c.mu.Lock()
+	c.serverInfo = serverInfo
+	c.mu.Unlock()
+
+	// Check for cancellation
+	if ctx.Err() != nil {
+		c.handleError(ctx, ctx.Err(), "Operation cancelled during provisioning")
+		return
+	}
+
+	// Step 6: Transition to Connecting
+	c.mu.Lock()
+	if err := c.setState(StateConnecting, "Establishing VPN connection..."); err != nil {
 		c.mu.Unlock()
+		c.handleError(ctx, err, "Failed to transition to connecting state")
 		return
 	}
 	c.mu.Unlock()
 
-	// STUB: Simulate connecting
-	select {
-	case <-ctx.Done():
-		c.handleError(ctx.Err(), "Operation cancelled during connection")
+	// Step 7: Connect WireGuard
+	if c.wgClient == nil {
+		c.handleError(ctx, fmt.Errorf("no WireGuard client configured"), "WireGuard client required")
 		return
-	case <-time.After(2 * time.Second):
-		// Continue
 	}
 
+	if err := c.wgClient.Connect(ctx, serverInfo, keyPair); err != nil {
+		c.handleError(ctx, err, fmt.Sprintf("Failed to connect WireGuard: %v", err))
+		return
+	}
+
+	// Step 8: Transition to Connected
 	c.mu.Lock()
 	if err := c.setState(StateConnected, "Connected successfully"); err != nil {
 		c.mu.Unlock()
@@ -236,41 +351,51 @@ func (c *Controller) doConnect(ctx context.Context) {
 	c.mu.Unlock()
 }
 
-// doDisconnect performs the disconnection process (stub implementation)
+// doDisconnect performs the disconnection process
 func (c *Controller) doDisconnect(ctx context.Context) {
-	// STUB: Simulate disconnecting
-	select {
-	case <-ctx.Done():
-		// For disconnect, we continue even if cancelled to ensure cleanup
-	case <-time.After(1 * time.Second):
-		// Continue
+	// Step 1: Disconnect WireGuard (log errors but continue)
+	if c.wgClient != nil {
+		if err := c.wgClient.Disconnect(ctx); err != nil {
+			log.Printf("Warning: failed to disconnect WireGuard: %v", err)
+		}
 	}
 
+	// Step 2: Transition to Deprovisioning
 	c.mu.Lock()
 	if err := c.setState(StateDeprovisioning, "Cleaning up resources..."); err != nil {
 		c.mu.Unlock()
+		log.Printf("Warning: failed to transition to deprovisioning: %v", err)
 		return
 	}
+	activeProvider := c.activeProvider
 	c.mu.Unlock()
 
-	// STUB: Simulate deprovisioning
-	select {
-	case <-ctx.Done():
-		// Continue cleanup regardless
-	case <-time.After(1 * time.Second):
-		// Continue
+	// Step 3: Deprovision infrastructure (log errors but continue)
+	if activeProvider != nil {
+		if err := activeProvider.Deprovision(ctx); err != nil {
+			log.Printf("Warning: failed to deprovision infrastructure: %v", err)
+		}
 	}
 
+	// Step 4: Clear session state
+	c.mu.Lock()
+	c.activeProvider = nil
+	c.serverInfo = nil
+	c.clientKeyPair = nil
+	c.mu.Unlock()
+
+	// Step 5: Transition to Disconnected
 	c.mu.Lock()
 	if err := c.setState(StateDisconnected, "Disconnected"); err != nil {
 		c.mu.Unlock()
+		log.Printf("Warning: failed to transition to disconnected: %v", err)
 		return
 	}
 	c.mu.Unlock()
 }
 
 // handleError is called when an error occurs during operations
-func (c *Controller) handleError(err error, message string) {
+func (c *Controller) handleError(ctx context.Context, err error, message string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -287,21 +412,52 @@ func (c *Controller) handleError(err error, message string) {
 	}
 
 	// Attempt cleanup in background
-	go c.cleanup()
+	// Note: We pass the original context but cleanup may use its own
+	// context if needed to ensure resources are freed
+	go c.cleanup(ctx)
 }
 
 // cleanup performs cleanup after error
-func (c *Controller) cleanup() {
-	// STUB: In future, this will:
-	// 1. Call provider.Deprovision()
-	// 2. Tear down WireGuard tunnel
-	// 3. Release resources
+// Note: We intentionally use a fresh context for cleanup operations
+// to ensure they complete even if the original context was cancelled.
+// This is critical to avoid leaving cloud resources running.
+//
+//nolint:contextcheck // Intentionally using fresh context for cleanup
+func (c *Controller) cleanup(_ context.Context) {
+	// Use a fresh context for cleanup to ensure it completes
+	// even if the original context was cancelled
+	cleanupCtx := context.Background()
 
-	time.Sleep(500 * time.Millisecond) // Simulate cleanup
+	// Step 1: Check if WireGuard is connected and disconnect if so
+	if c.wgClient != nil {
+		status := c.wgClient.Status()
+		if status.Connected {
+			if err := c.wgClient.Disconnect(cleanupCtx); err != nil {
+				log.Printf("Warning: failed to disconnect WireGuard during cleanup: %v", err)
+			}
+		}
+	}
 
+	// Step 2: Check if provider exists and deprovision if so
+	c.mu.Lock()
+	activeProvider := c.activeProvider
+	c.mu.Unlock()
+
+	if activeProvider != nil {
+		if err := activeProvider.Deprovision(cleanupCtx); err != nil {
+			log.Printf("Warning: failed to deprovision during cleanup: %v", err)
+		}
+	}
+
+	// Step 3: Clear session state
+	c.mu.Lock()
+	c.activeProvider = nil
+	c.serverInfo = nil
+	c.clientKeyPair = nil
+	c.mu.Unlock()
+
+	// Step 4: Transition back to Disconnected after cleanup
 	c.mu.Lock()
 	defer c.mu.Unlock()
-
-	// Transition back to Disconnected after cleanup
 	_ = c.setState(StateDisconnected, "Cleanup completed")
 }

--- a/internal/app/controller_test.go
+++ b/internal/app/controller_test.go
@@ -6,10 +6,18 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/gonfva/my-own-vpn/internal/config"
+	"github.com/gonfva/my-own-vpn/internal/provider"
 )
 
+// newTestController creates a controller with empty dependencies for basic tests
+func newTestController() *Controller {
+	return NewController(ControllerDeps{})
+}
+
 func TestNewController(t *testing.T) {
-	c := NewController()
+	c := newTestController()
 
 	if c == nil {
 		t.Fatal("NewController returned nil")
@@ -47,7 +55,7 @@ func TestStateString(t *testing.T) {
 }
 
 func TestValidTransitions(t *testing.T) {
-	c := NewController()
+	c := newTestController()
 
 	tests := []struct {
 		from  State
@@ -83,7 +91,7 @@ func TestValidTransitions(t *testing.T) {
 }
 
 func TestSetStateCallbacks(t *testing.T) {
-	c := NewController()
+	c := newTestController()
 
 	done := make(chan bool)
 	var receivedState State
@@ -121,113 +129,8 @@ func TestSetStateCallbacks(t *testing.T) {
 	}
 }
 
-func TestConnectStub(t *testing.T) {
-	c := NewController()
-
-	done := make(chan bool, 10)
-	var stateChanges []State
-	var mu sync.Mutex
-
-	c.SetOnStateChange(func(state State, msg string) {
-		mu.Lock()
-		stateChanges = append(stateChanges, state)
-		mu.Unlock()
-		done <- true
-	})
-
-	ctx := context.Background()
-	err := c.Connect(ctx)
-
-	if err != nil {
-		t.Fatalf("Connect returned error: %v", err)
-	}
-
-	// Wait for 3 state changes: Provisioning -> Connecting -> Connected
-	for i := 0; i < 3; i++ {
-		select {
-		case <-done:
-			// Got state change
-		case <-time.After(10 * time.Second):
-			t.Fatalf("timeout waiting for state change %d", i+1)
-		}
-	}
-
-	// Should have transitioned: Provisioning -> Connecting -> Connected
-	expectedStates := []State{StateProvisioning, StateConnecting, StateConnected}
-
-	mu.Lock()
-	if len(stateChanges) != len(expectedStates) {
-		t.Errorf("expected %d state changes, got %d: %v", len(expectedStates), len(stateChanges), stateChanges)
-	}
-
-	for i, expected := range expectedStates {
-		if i >= len(stateChanges) {
-			break
-		}
-		if stateChanges[i] != expected {
-			t.Errorf("state change %d: expected %v, got %v", i, expected, stateChanges[i])
-		}
-	}
-	mu.Unlock()
-
-	if c.State() != StateConnected {
-		t.Errorf("expected final state Connected, got %v", c.State())
-	}
-}
-
-func TestDisconnectStub(t *testing.T) {
-	c := NewController()
-
-	// First manually set to Connected state
-	c.mu.Lock()
-	c.state = StateConnected
-	c.sessionStart = time.Now()
-	c.mu.Unlock()
-
-	done := make(chan bool, 10)
-	var stateChanges []State
-	var mu sync.Mutex
-
-	c.SetOnStateChange(func(state State, msg string) {
-		mu.Lock()
-		stateChanges = append(stateChanges, state)
-		mu.Unlock()
-		done <- true
-	})
-
-	ctx := context.Background()
-	err := c.Disconnect(ctx)
-
-	if err != nil {
-		t.Fatalf("Disconnect returned error: %v", err)
-	}
-
-	// Wait for 3 state changes: Disconnecting -> Deprovisioning -> Disconnected
-	for i := 0; i < 3; i++ {
-		select {
-		case <-done:
-			// Got state change
-		case <-time.After(10 * time.Second):
-			t.Fatalf("timeout waiting for state change %d", i+1)
-		}
-	}
-
-	// Should have transitioned: Disconnecting -> Deprovisioning -> Disconnected
-	expectedStates := []State{StateDisconnecting, StateDeprovisioning, StateDisconnected}
-
-	mu.Lock()
-	if len(stateChanges) != len(expectedStates) {
-		t.Errorf("expected %d state changes, got %d: %v", len(expectedStates), len(stateChanges), stateChanges)
-	}
-	mu.Unlock()
-
-	if c.State() != StateDisconnected {
-		t.Errorf("expected final state Disconnected, got %v", c.State())
-	}
-}
-
 func TestSessionDuration(t *testing.T) {
-	c := NewController()
+	c := newTestController()
 
 	// When disconnected, duration should be 0
 	if d := c.SessionDuration(); d != 0 {
@@ -257,42 +160,8 @@ func TestSessionDuration(t *testing.T) {
 	}
 }
 
-func TestCancel(t *testing.T) {
-	c := NewController()
-
-	ctx := context.Background()
-
-	// Start connection
-	err := c.Connect(ctx)
-	if err != nil {
-		t.Fatalf("Connect returned error: %v", err)
-	}
-
-	// Wait a bit
-	time.Sleep(500 * time.Millisecond)
-
-	// Cancel should work
-	c.Cancel()
-
-	// Check that cancelFunc was called
-	c.mu.RLock()
-	if c.cancelFunc != nil {
-		t.Error("cancelFunc should be nil after Cancel()")
-	}
-	c.mu.RUnlock()
-
-	// Wait for error handling to complete
-	time.Sleep(1 * time.Second)
-
-	// Should end up in Error or Disconnected state after cleanup
-	finalState := c.State()
-	if finalState != StateError && finalState != StateDisconnected {
-		t.Errorf("expected Error or Disconnected state after cancel, got %v", finalState)
-	}
-}
-
 func TestInvalidStateOperations(t *testing.T) {
-	c := NewController()
+	c := newTestController()
 	ctx := context.Background()
 
 	// Try to disconnect when not connected
@@ -325,7 +194,22 @@ func TestInvalidStateOperations(t *testing.T) {
 }
 
 func TestThreadSafety(t *testing.T) {
-	c := NewController()
+	mockProvider := &MockProvider{}
+	mockWG := &MockWireGuardClient{}
+	mockCreds := &MockCredentialsManager{}
+
+	c := NewController(ControllerDeps{
+		CredentialsManager: mockCreds,
+		WireGuardClient:    mockWG,
+		ProviderFactory: func(_ context.Context, _, _ string) (provider.Provider, error) {
+			return mockProvider, nil
+		},
+	})
+	c.SetConfig(&config.Config{
+		Provider:     "aws",
+		Region:       "us-east-1",
+		InstanceType: "t3.micro",
+	})
 
 	// Run with -race flag to detect races
 	done := make(chan bool)
@@ -356,7 +240,7 @@ func TestThreadSafety(t *testing.T) {
 }
 
 func TestErrorCallback(t *testing.T) {
-	c := NewController()
+	c := newTestController()
 
 	// Set controller to a state that can transition to Error (Provisioning)
 	c.mu.Lock()
@@ -373,7 +257,7 @@ func TestErrorCallback(t *testing.T) {
 
 	// Manually trigger an error
 	testErr := context.Canceled
-	c.handleError(testErr, "test error")
+	c.handleError(context.Background(), testErr, "test error")
 
 	// Wait for error callback
 	select {
@@ -397,7 +281,7 @@ func TestErrorCallback(t *testing.T) {
 }
 
 func TestInvalidTransitionRejected(t *testing.T) {
-	c := NewController()
+	c := newTestController()
 
 	// Try an invalid transition
 	c.mu.Lock()
@@ -412,4 +296,621 @@ func TestInvalidTransitionRejected(t *testing.T) {
 	if c.State() != StateDisconnected {
 		t.Errorf("expected state to remain Disconnected, got %v", c.State())
 	}
+}
+
+// ============ Real flow tests with mocks ============
+
+func TestConnect_Success(t *testing.T) {
+	mockProvider := &MockProvider{}
+	mockWG := &MockWireGuardClient{}
+	mockCreds := &MockCredentialsManager{}
+
+	c := NewController(ControllerDeps{
+		CredentialsManager: mockCreds,
+		WireGuardClient:    mockWG,
+		ProviderFactory: func(_ context.Context, _, _ string) (provider.Provider, error) {
+			return mockProvider, nil
+		},
+	})
+
+	c.SetConfig(&config.Config{
+		Provider:     "aws",
+		Region:       "us-east-1",
+		InstanceType: "t3.micro",
+	})
+
+	connectedDone := make(chan bool, 1)
+	var stateSet = make(map[State]bool)
+	var mu sync.Mutex
+
+	c.SetOnStateChange(func(state State, _ string) {
+		mu.Lock()
+		stateSet[state] = true
+		mu.Unlock()
+		if state == StateConnected {
+			connectedDone <- true
+		}
+	})
+
+	ctx := context.Background()
+	err := c.Connect(ctx)
+
+	if err != nil {
+		t.Fatalf("Connect returned error: %v", err)
+	}
+
+	// Wait for Connected state
+	select {
+	case <-connectedDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for Connected state")
+	}
+
+	// Small delay to allow all async state callbacks to complete
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify all expected states occurred (order may vary due to async callbacks)
+	expectedStates := []State{StateProvisioning, StateConnecting, StateConnected}
+	mu.Lock()
+	for _, expected := range expectedStates {
+		if !stateSet[expected] {
+			t.Errorf("expected state %v to be reached", expected)
+		}
+	}
+	mu.Unlock()
+
+	if c.State() != StateConnected {
+		t.Errorf("expected final state Connected, got %v", c.State())
+	}
+
+	// Verify mock calls
+	if !mockProvider.ValidateCalled {
+		t.Error("expected provider.ValidateCredentials to be called")
+	}
+	if !mockProvider.ProvisionCalled {
+		t.Error("expected provider.Provision to be called")
+	}
+	if !mockWG.ConnectCalled {
+		t.Error("expected wgClient.Connect to be called")
+	}
+}
+
+func TestDisconnect_Success(t *testing.T) {
+	mockProvider := &MockProvider{}
+	mockWG := &MockWireGuardClient{}
+	mockWG.SetConnected(true)
+
+	c := NewController(ControllerDeps{
+		CredentialsManager: &MockCredentialsManager{},
+		WireGuardClient:    mockWG,
+		ProviderFactory: func(_ context.Context, _, _ string) (provider.Provider, error) {
+			return mockProvider, nil
+		},
+	})
+
+	// Set up as connected
+	c.mu.Lock()
+	c.state = StateConnected
+	c.sessionStart = time.Now()
+	c.activeProvider = mockProvider
+	c.mu.Unlock()
+
+	done := make(chan bool, 10)
+	var stateChanges []State
+	var mu sync.Mutex
+
+	c.SetOnStateChange(func(state State, _ string) {
+		mu.Lock()
+		stateChanges = append(stateChanges, state)
+		mu.Unlock()
+		done <- true
+	})
+
+	ctx := context.Background()
+	err := c.Disconnect(ctx)
+
+	if err != nil {
+		t.Fatalf("Disconnect returned error: %v", err)
+	}
+
+	// Wait for 3 state changes: Disconnecting -> Deprovisioning -> Disconnected
+	for i := 0; i < 3; i++ {
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timeout waiting for state change %d", i+1)
+		}
+	}
+
+	expectedStates := []State{StateDisconnecting, StateDeprovisioning, StateDisconnected}
+	mu.Lock()
+	if len(stateChanges) != len(expectedStates) {
+		t.Errorf("expected %d state changes, got %d: %v", len(expectedStates), len(stateChanges), stateChanges)
+	}
+	mu.Unlock()
+
+	if c.State() != StateDisconnected {
+		t.Errorf("expected final state Disconnected, got %v", c.State())
+	}
+
+	// Verify mock calls
+	if !mockWG.DisconnectCalled {
+		t.Error("expected wgClient.Disconnect to be called")
+	}
+	if !mockProvider.DeprovisionCalled {
+		t.Error("expected provider.Deprovision to be called")
+	}
+}
+
+func TestConnect_NoConfig(t *testing.T) {
+	mockProvider := &MockProvider{}
+	mockWG := &MockWireGuardClient{}
+
+	c := NewController(ControllerDeps{
+		CredentialsManager: &MockCredentialsManager{},
+		WireGuardClient:    mockWG,
+		ProviderFactory: func(_ context.Context, _, _ string) (provider.Provider, error) {
+			return mockProvider, nil
+		},
+	})
+
+	// No config set
+	errorCalled := make(chan bool, 1)
+	c.SetOnError(func(_ error) {
+		errorCalled <- true
+	})
+
+	ctx := context.Background()
+	err := c.Connect(ctx)
+
+	if err != nil {
+		t.Fatalf("Connect should not return immediate error: %v", err)
+	}
+
+	// Wait for error callback
+	select {
+	case <-errorCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected error callback for missing config")
+	}
+
+	// Wait for cleanup
+	time.Sleep(500 * time.Millisecond)
+
+	if c.State() != StateDisconnected {
+		t.Errorf("expected Disconnected state after error, got %v", c.State())
+	}
+}
+
+func TestConnect_InvalidConfig(t *testing.T) {
+	mockProvider := &MockProvider{}
+	mockWG := &MockWireGuardClient{}
+
+	c := NewController(ControllerDeps{
+		CredentialsManager: &MockCredentialsManager{},
+		WireGuardClient:    mockWG,
+		ProviderFactory: func(_ context.Context, _, _ string) (provider.Provider, error) {
+			return mockProvider, nil
+		},
+	})
+
+	// Set invalid config
+	c.SetConfig(&config.Config{
+		Provider: "invalid-provider",
+		Region:   "us-east-1",
+	})
+
+	errorCalled := make(chan bool, 1)
+	c.SetOnError(func(_ error) {
+		errorCalled <- true
+	})
+
+	ctx := context.Background()
+	_ = c.Connect(ctx)
+
+	// Wait for error callback
+	select {
+	case <-errorCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected error callback for invalid config")
+	}
+
+	// Wait for cleanup
+	time.Sleep(500 * time.Millisecond)
+
+	if c.State() != StateDisconnected {
+		t.Errorf("expected Disconnected state after error, got %v", c.State())
+	}
+}
+
+func TestConnect_CredentialValidationFails(t *testing.T) {
+	mockProvider := &MockProvider{}
+	mockProvider.SetValidateError(errors.New("invalid credentials"))
+	mockWG := &MockWireGuardClient{}
+
+	c := NewController(ControllerDeps{
+		CredentialsManager: &MockCredentialsManager{},
+		WireGuardClient:    mockWG,
+		ProviderFactory: func(_ context.Context, _, _ string) (provider.Provider, error) {
+			return mockProvider, nil
+		},
+	})
+
+	c.SetConfig(&config.Config{
+		Provider:     "aws",
+		Region:       "us-east-1",
+		InstanceType: "t3.micro",
+	})
+
+	errorCalled := make(chan bool, 1)
+	c.SetOnError(func(_ error) {
+		errorCalled <- true
+	})
+
+	ctx := context.Background()
+	_ = c.Connect(ctx)
+
+	// Wait for error callback
+	select {
+	case <-errorCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected error callback for credential validation failure")
+	}
+
+	// Wait for cleanup
+	time.Sleep(500 * time.Millisecond)
+
+	if c.State() != StateDisconnected {
+		t.Errorf("expected Disconnected state after error, got %v", c.State())
+	}
+}
+
+func TestConnect_ProvisionFails(t *testing.T) {
+	mockProvider := &MockProvider{}
+	mockProvider.SetProvisionError(errors.New("provision failed"))
+	mockWG := &MockWireGuardClient{}
+
+	c := NewController(ControllerDeps{
+		CredentialsManager: &MockCredentialsManager{},
+		WireGuardClient:    mockWG,
+		ProviderFactory: func(_ context.Context, _, _ string) (provider.Provider, error) {
+			return mockProvider, nil
+		},
+	})
+
+	c.SetConfig(&config.Config{
+		Provider:     "aws",
+		Region:       "us-east-1",
+		InstanceType: "t3.micro",
+	})
+
+	errorCalled := make(chan bool, 1)
+	c.SetOnError(func(_ error) {
+		errorCalled <- true
+	})
+
+	ctx := context.Background()
+	_ = c.Connect(ctx)
+
+	// Wait for error callback
+	select {
+	case <-errorCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected error callback for provision failure")
+	}
+
+	// Wait for cleanup
+	time.Sleep(500 * time.Millisecond)
+
+	// Should have attempted cleanup (deprovision)
+	if !mockProvider.DeprovisionCalled {
+		t.Error("expected provider.Deprovision to be called during cleanup")
+	}
+
+	if c.State() != StateDisconnected {
+		t.Errorf("expected Disconnected state after error, got %v", c.State())
+	}
+}
+
+func TestConnect_WireGuardFails(t *testing.T) {
+	mockProvider := &MockProvider{}
+	mockWG := &MockWireGuardClient{}
+	mockWG.SetConnectError(errors.New("wireguard connection failed"))
+
+	c := NewController(ControllerDeps{
+		CredentialsManager: &MockCredentialsManager{},
+		WireGuardClient:    mockWG,
+		ProviderFactory: func(_ context.Context, _, _ string) (provider.Provider, error) {
+			return mockProvider, nil
+		},
+	})
+
+	c.SetConfig(&config.Config{
+		Provider:     "aws",
+		Region:       "us-east-1",
+		InstanceType: "t3.micro",
+	})
+
+	errorCalled := make(chan bool, 1)
+	c.SetOnError(func(_ error) {
+		errorCalled <- true
+	})
+
+	ctx := context.Background()
+	_ = c.Connect(ctx)
+
+	// Wait for error callback
+	select {
+	case <-errorCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected error callback for WireGuard failure")
+	}
+
+	// Wait for cleanup
+	time.Sleep(500 * time.Millisecond)
+
+	// Should have attempted cleanup (deprovision)
+	if !mockProvider.DeprovisionCalled {
+		t.Error("expected provider.Deprovision to be called during cleanup")
+	}
+
+	if c.State() != StateDisconnected {
+		t.Errorf("expected Disconnected state after error, got %v", c.State())
+	}
+}
+
+func TestDisconnect_WireGuardFails(t *testing.T) {
+	mockProvider := &MockProvider{}
+	mockWG := &MockWireGuardClient{}
+	mockWG.SetConnected(true)
+	mockWG.SetDisconnectError(errors.New("wireguard disconnect failed"))
+
+	c := NewController(ControllerDeps{
+		CredentialsManager: &MockCredentialsManager{},
+		WireGuardClient:    mockWG,
+		ProviderFactory: func(_ context.Context, _, _ string) (provider.Provider, error) {
+			return mockProvider, nil
+		},
+	})
+
+	// Set up as connected
+	c.mu.Lock()
+	c.state = StateConnected
+	c.sessionStart = time.Now()
+	c.activeProvider = mockProvider
+	c.mu.Unlock()
+
+	done := make(chan bool, 10)
+	c.SetOnStateChange(func(state State, _ string) {
+		if state == StateDisconnected {
+			done <- true
+		}
+	})
+
+	ctx := context.Background()
+	_ = c.Disconnect(ctx)
+
+	// Should still complete despite WireGuard error
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("expected disconnect to complete despite WireGuard error")
+	}
+
+	if c.State() != StateDisconnected {
+		t.Errorf("expected Disconnected state, got %v", c.State())
+	}
+
+	// Deprovision should still be called
+	if !mockProvider.DeprovisionCalled {
+		t.Error("expected provider.Deprovision to be called even after WireGuard error")
+	}
+}
+
+func TestDisconnect_DeprovisionFails(t *testing.T) {
+	mockProvider := &MockProvider{}
+	mockProvider.SetDeprovisionError(errors.New("deprovision failed"))
+	mockWG := &MockWireGuardClient{}
+	mockWG.SetConnected(true)
+
+	c := NewController(ControllerDeps{
+		CredentialsManager: &MockCredentialsManager{},
+		WireGuardClient:    mockWG,
+		ProviderFactory: func(_ context.Context, _, _ string) (provider.Provider, error) {
+			return mockProvider, nil
+		},
+	})
+
+	// Set up as connected
+	c.mu.Lock()
+	c.state = StateConnected
+	c.sessionStart = time.Now()
+	c.activeProvider = mockProvider
+	c.mu.Unlock()
+
+	done := make(chan bool, 10)
+	c.SetOnStateChange(func(state State, _ string) {
+		if state == StateDisconnected {
+			done <- true
+		}
+	})
+
+	ctx := context.Background()
+	_ = c.Disconnect(ctx)
+
+	// Should still reach Disconnected state despite deprovision error
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("expected disconnect to complete despite deprovision error")
+	}
+
+	if c.State() != StateDisconnected {
+		t.Errorf("expected Disconnected state, got %v", c.State())
+	}
+}
+
+func TestConnect_Cancelled(t *testing.T) {
+	// Create a slow mock provider that allows us to cancel during provisioning
+	slowProvider := &MockProvider{}
+
+	provisionStarted := make(chan bool, 1)
+	provisionBlocked := make(chan bool)
+
+	c := NewController(ControllerDeps{
+		CredentialsManager: &MockCredentialsManager{},
+		WireGuardClient:    &MockWireGuardClient{},
+		ProviderFactory: func(ctx context.Context, _, _ string) (provider.Provider, error) {
+			// Signal that we've entered the provider factory
+			select {
+			case provisionStarted <- true:
+			default:
+			}
+			// Block until we receive a signal or context is cancelled
+			select {
+			case <-provisionBlocked:
+				return slowProvider, nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+	})
+
+	c.SetConfig(&config.Config{
+		Provider:     "aws",
+		Region:       "us-east-1",
+		InstanceType: "t3.micro",
+	})
+
+	errorCalled := make(chan bool, 1)
+	c.SetOnError(func(_ error) {
+		errorCalled <- true
+	})
+
+	ctx := context.Background()
+	err := c.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect returned error: %v", err)
+	}
+
+	// Wait for provision to start
+	select {
+	case <-provisionStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for provisioning to start")
+	}
+
+	// Cancel the operation
+	c.Cancel()
+
+	// Wait for error callback or timeout
+	select {
+	case <-errorCalled:
+		// Expected - cancellation triggered error
+	case <-time.After(2 * time.Second):
+		// Also acceptable - if the operation finished before cancel took effect
+	}
+
+	// Allow some time for cleanup
+	time.Sleep(500 * time.Millisecond)
+
+	// Should be disconnected after cancel and cleanup
+	finalState := c.State()
+	if finalState != StateError && finalState != StateDisconnected {
+		t.Errorf("expected Error or Disconnected state after cancel, got %v", finalState)
+	}
+}
+
+func TestConnectThenDisconnect(t *testing.T) {
+	mockProvider := &MockProvider{}
+	mockWG := &MockWireGuardClient{}
+
+	c := NewController(ControllerDeps{
+		CredentialsManager: &MockCredentialsManager{},
+		WireGuardClient:    mockWG,
+		ProviderFactory: func(_ context.Context, _, _ string) (provider.Provider, error) {
+			return mockProvider, nil
+		},
+	})
+
+	c.SetConfig(&config.Config{
+		Provider:     "aws",
+		Region:       "us-east-1",
+		InstanceType: "t3.micro",
+	})
+
+	connectedDone := make(chan bool, 1)
+	disconnectedDone := make(chan bool, 1)
+
+	c.SetOnStateChange(func(state State, _ string) {
+		switch state {
+		case StateConnected:
+			connectedDone <- true
+		case StateDisconnected:
+			disconnectedDone <- true
+		}
+	})
+
+	ctx := context.Background()
+
+	// Connect
+	_ = c.Connect(ctx)
+
+	select {
+	case <-connectedDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for Connected state")
+	}
+
+	if c.State() != StateConnected {
+		t.Fatalf("expected Connected, got %v", c.State())
+	}
+
+	// Disconnect
+	_ = c.Disconnect(ctx)
+
+	select {
+	case <-disconnectedDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for Disconnected state")
+	}
+
+	if c.State() != StateDisconnected {
+		t.Errorf("expected Disconnected, got %v", c.State())
+	}
+
+	// Verify all operations were called
+	if !mockProvider.ValidateCalled {
+		t.Error("expected provider.ValidateCredentials to be called")
+	}
+	if !mockProvider.ProvisionCalled {
+		t.Error("expected provider.Provision to be called")
+	}
+	if !mockWG.ConnectCalled {
+		t.Error("expected wgClient.Connect to be called")
+	}
+	if !mockWG.DisconnectCalled {
+		t.Error("expected wgClient.Disconnect to be called")
+	}
+	if !mockProvider.DeprovisionCalled {
+		t.Error("expected provider.Deprovision to be called")
+	}
+}
+
+func TestSetConfig(t *testing.T) {
+	c := newTestController()
+
+	cfg := &config.Config{
+		Provider:     "hetzner",
+		Region:       "fsn1",
+		InstanceType: "cx11",
+	}
+
+	c.SetConfig(cfg)
+
+	c.mu.RLock()
+	if c.config != cfg {
+		t.Error("expected config to be set")
+	}
+	c.mu.RUnlock()
 }

--- a/internal/app/mocks_test.go
+++ b/internal/app/mocks_test.go
@@ -1,0 +1,258 @@
+package app
+
+import (
+	"context"
+	"sync"
+
+	"github.com/gonfva/my-own-vpn/internal/credentials"
+	"github.com/gonfva/my-own-vpn/internal/provider"
+	"github.com/gonfva/my-own-vpn/internal/wireguard"
+)
+
+// MockCredentialsManager is a mock implementation of credentials.Manager for testing
+type MockCredentialsManager struct {
+	mu sync.Mutex
+
+	// AWS credentials
+	awsCreds    *credentials.AWSCredentials
+	awsLoadErr  error
+	awsSaveErr  error
+	hasAWSCreds bool
+
+	// Hetzner credentials
+	hetznerCreds    *credentials.HetznerCredentials
+	hetznerLoadErr  error
+	hetznerSaveErr  error
+	hasHetznerCreds bool
+}
+
+func (m *MockCredentialsManager) SaveAWS(_ context.Context, creds credentials.AWSCredentials) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.awsSaveErr != nil {
+		return m.awsSaveErr
+	}
+	m.awsCreds = &creds
+	m.hasAWSCreds = true
+	return nil
+}
+
+func (m *MockCredentialsManager) LoadAWS(_ context.Context) (*credentials.AWSCredentials, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.awsLoadErr != nil {
+		return nil, m.awsLoadErr
+	}
+	return m.awsCreds, nil
+}
+
+func (m *MockCredentialsManager) DeleteAWS(_ context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.awsCreds = nil
+	m.hasAWSCreds = false
+	return nil
+}
+
+func (m *MockCredentialsManager) SaveHetzner(_ context.Context, creds credentials.HetznerCredentials) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.hetznerSaveErr != nil {
+		return m.hetznerSaveErr
+	}
+	m.hetznerCreds = &creds
+	m.hasHetznerCreds = true
+	return nil
+}
+
+func (m *MockCredentialsManager) LoadHetzner(_ context.Context) (*credentials.HetznerCredentials, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.hetznerLoadErr != nil {
+		return nil, m.hetznerLoadErr
+	}
+	return m.hetznerCreds, nil
+}
+
+func (m *MockCredentialsManager) DeleteHetzner(_ context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.hetznerCreds = nil
+	m.hasHetznerCreds = false
+	return nil
+}
+
+func (m *MockCredentialsManager) HasCredentials(_ context.Context, providerType string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	switch providerType {
+	case "aws":
+		return m.hasAWSCreds
+	case "hetzner":
+		return m.hasHetznerCreds
+	default:
+		return false
+	}
+}
+
+// Ensure MockCredentialsManager implements credentials.Manager
+var _ credentials.Manager = (*MockCredentialsManager)(nil)
+
+// MockProvider is a mock implementation of provider.Provider for testing
+type MockProvider struct {
+	mu sync.Mutex
+
+	// Control behavior
+	validateErr    error
+	provisionErr   error
+	deprovisionErr error
+	serverInfo     *provider.ServerInfo
+
+	// Track calls
+	ValidateCalled    bool
+	ProvisionCalled   bool
+	DeprovisionCalled bool
+	ProvisionConfig   provider.ProvisionConfig
+}
+
+func (m *MockProvider) ValidateCredentials(_ context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ValidateCalled = true
+	return m.validateErr
+}
+
+func (m *MockProvider) ListRegions(_ context.Context) ([]provider.Region, error) {
+	return []provider.Region{{ID: "test-region", Name: "Test Region"}}, nil
+}
+
+func (m *MockProvider) Provision(_ context.Context, cfg provider.ProvisionConfig) (*provider.ServerInfo, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ProvisionCalled = true
+	m.ProvisionConfig = cfg
+	if m.provisionErr != nil {
+		return nil, m.provisionErr
+	}
+	if m.serverInfo != nil {
+		return m.serverInfo, nil
+	}
+	return &provider.ServerInfo{
+		PublicIP:        "1.2.3.4",
+		WireGuardPort:   51820,
+		ServerPublicKey: "test-server-public-key",
+	}, nil
+}
+
+func (m *MockProvider) Deprovision(_ context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.DeprovisionCalled = true
+	return m.deprovisionErr
+}
+
+func (m *MockProvider) GetStatus(_ context.Context) (*provider.InfraStatus, error) {
+	return &provider.InfraStatus{State: provider.StateRunning, Message: "Running"}, nil
+}
+
+func (m *MockProvider) EstimateCost(_ provider.ProvisionConfig) provider.CostEstimate {
+	return provider.CostEstimate{HourlyRate: 0.01, Currency: "USD"}
+}
+
+// SetProvisionError sets the error to return from Provision
+func (m *MockProvider) SetProvisionError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.provisionErr = err
+}
+
+// SetValidateError sets the error to return from ValidateCredentials
+func (m *MockProvider) SetValidateError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.validateErr = err
+}
+
+// SetDeprovisionError sets the error to return from Deprovision
+func (m *MockProvider) SetDeprovisionError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.deprovisionErr = err
+}
+
+// Ensure MockProvider implements provider.Provider
+var _ provider.Provider = (*MockProvider)(nil)
+
+// MockWireGuardClient is a mock implementation of wireguard.Client for testing
+type MockWireGuardClient struct {
+	mu sync.Mutex
+
+	// Control behavior
+	connectErr    error
+	disconnectErr error
+	connected     bool
+
+	// Track calls
+	ConnectCalled    bool
+	DisconnectCalled bool
+	ServerInfo       *provider.ServerInfo
+	ClientKeyPair    *wireguard.KeyPair
+}
+
+func (m *MockWireGuardClient) Connect(_ context.Context, serverInfo *provider.ServerInfo, clientKeyPair *wireguard.KeyPair) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ConnectCalled = true
+	m.ServerInfo = serverInfo
+	m.ClientKeyPair = clientKeyPair
+	if m.connectErr != nil {
+		return m.connectErr
+	}
+	m.connected = true
+	return nil
+}
+
+func (m *MockWireGuardClient) Disconnect(_ context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.DisconnectCalled = true
+	if m.disconnectErr != nil {
+		return m.disconnectErr
+	}
+	m.connected = false
+	return nil
+}
+
+func (m *MockWireGuardClient) Status() wireguard.ConnectionStatus {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return wireguard.ConnectionStatus{Connected: m.connected}
+}
+
+func (m *MockWireGuardClient) GetPublicKey() string {
+	return "mock-client-public-key"
+}
+
+// SetConnectError sets the error to return from Connect
+func (m *MockWireGuardClient) SetConnectError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.connectErr = err
+}
+
+// SetDisconnectError sets the error to return from Disconnect
+func (m *MockWireGuardClient) SetDisconnectError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.disconnectErr = err
+}
+
+// SetConnected sets the connected state
+func (m *MockWireGuardClient) SetConnected(connected bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.connected = connected
+}
+
+// Ensure MockWireGuardClient implements wireguard.Client
+var _ wireguard.Client = (*MockWireGuardClient)(nil)


### PR DESCRIPTION
Replace the stub implementation in Controller with real functionality that:
- Validates configuration and credentials before connecting
- Provisions cloud infrastructure using AWS or Hetzner provider
- Establishes a WireGuard tunnel to the provisioned server
- Properly tears down resources on disconnect

Key changes:
- Add ControllerDeps struct for dependency injection
- Add ProviderFactory function type for creating providers
- Implement real doConnect() with config validation, provider creation, credential validation, key pair generation, and WireGuard connection
- Implement real doDisconnect() and cleanup() for proper resource teardown
- Wire up dependencies in main.go including credential storage on settings save
- Add comprehensive tests with mock implementations

## Description
<!-- Describe your changes -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
<!-- Describe how you tested your changes -->

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
